### PR TITLE
Add link to releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Hosts: Artem Zinnatullin [@artem_zin](https://twitter.com/artem_zin) & Hannes Do
 
 ---
 
-###Episodes
+###[Episodes](https://github.com/artem-zinnatullin/TheContext-Podcast/releases)
 
 #####Episode 1: Architecture of modern Android apps with [Hannes Dorfmann](https://twitter.com/sockeqwe)
  - [Show notes](https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_1.md)


### PR DESCRIPTION
It's not possible to embed an html5 audio player in the README like I had hoped. This could be one option for #41 so users could quickly get to the mp3 files in their browser.