### PR TITLE
Feed formatting

### DIFF
--- a/feed.rss
+++ b/feed.rss
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
 <channel>
 	<title>The Context #androiddev</title>
 	<link>https://github.com/artem-zinnatullin/TheContext-Podcast</link>
@@ -46,7 +46,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 1: Architecture of modern Android apps</h1>
 
@@ -85,7 +85,7 @@
 				<li><a href="https://github.com/google/dagger/issues/298">Gradle's incremental build issue with annotation processing</a></li>
 			</ul>
 		]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_2/The.Context.episode.2.mp3</guid>
@@ -104,7 +104,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 2: Testing</h1>
 
@@ -151,7 +151,7 @@
 				<li><a href="http://jakewharton.com/android-needs-a-simulator/">Android Needs A Simulator, Not An Emulator</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3</guid>
@@ -170,7 +170,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 3, Part 1: RxJava with its core developer David Karnok</h1>
 			<ul>
@@ -197,7 +197,7 @@
 
 			<p>David Karnok <a href="https://twitter.com/akarnokd">@akarnokd</a>, <a href="http://akarnokd.blogspot.com">personal blog</a>, <a href="https://github.com/akarnokd">GitHub</a></p>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_2/The.Context.episode.3.Part2.mp3</guid>
@@ -216,7 +216,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 3, Part 2: RxJava tech details with its core developer David Karnok</h1>
 
@@ -243,7 +243,7 @@
 
 			<p>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></p>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_4/The.Context.episode.4.mp3</guid>
@@ -257,7 +257,7 @@
 			<atom:name>Chris Lacy</atom:name>
 			<atom:uri>https://twitter.com/chrismlacy</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 4: Indie Development</h1>
 
@@ -303,7 +303,7 @@
 				<li><a href="https://github.com/brave/browser-android">Link Bubble</a> has been open sourced</li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_5/The.Context.episode.5.mp3</guid>
@@ -317,7 +317,7 @@
 			<atom:name>Joe Birch</atom:name>
 			<atom:uri>http://hitherejoe.com/</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 5: Android TV</h1>
 
@@ -360,7 +360,7 @@
 				<li><a href="https://youtu.be/qv-e1sV3gos">Bring your Android app to Android TV in minutes </a>: Google I/O 2016</li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part1.mp3</guid>
@@ -374,7 +374,7 @@
 			<atom:name>Fernando Cejas</atom:name>
 			<atom:uri>http://fernandocejas.com/</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 6, Part1: Continuous Integration (CI) &amp; Continuous Delivery (CD)</h1>
 
@@ -414,7 +414,7 @@
 			<li><a href="https://github.com/android10/Android-CleanArchitecture">Fernando's Clean Architecture sample on github</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part2.mp3</guid>
@@ -428,7 +428,7 @@
 			<atom:name>Fernando Cejas</atom:name>
 			<atom:uri>http://fernandocejas.com/</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 6, Part2: Continuous Integration (CI) &amp; Continuous Delivery (CD) with Fernando Cejas from SoundCloud</h1>
 
@@ -468,7 +468,7 @@
 				<li><a href="http://hannesdorfmann.com/android/from-prefabricated-house-to-lego-house">From Prefab House to Lego House</a> - Blog post about depending on a shared library</li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3</guid>
@@ -482,7 +482,7 @@
 			<atom:name>Felipe Lima</atom:name>
 			<atom:uri>https://medium.com/@felipecsl</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 7: React Native with Felipe Lima from Airbnb</h1>
 
@@ -523,7 +523,7 @@
 			<li><a href="https://www.youtube.com/watch?v=npwa3ZmG9VQ">ReactiveConf 2016 (YouTube)</a> - Bridging the Gap: How to use React Native in existing large native code bases by Airbnb engineer Leland Richardson.</li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3</guid>
@@ -537,7 +537,7 @@
 			<atom:name>Paco Estevez</atom:name>
 			<atom:uri>http://www.pacoworks.com/</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 8: Damn Functional Programming with Paco Estevez</h1>
 
@@ -588,7 +588,7 @@
 			<li><a href="https://github.com/pakoito/RxTuples2">RxTuples</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part1.mp3</guid>
@@ -602,7 +602,7 @@
 			<atom:name>Alexey Tsvetkov</atom:name>
 			<atom:uri>https://twitter.com/tsvtkv</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</h1>
 
@@ -654,7 +654,7 @@
 			<li><a href="https://kotlinlang.org/docs/tutorials/koans.html">Kotlin Koans</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part2.mp3</guid>
@@ -668,7 +668,7 @@
 			<atom:name>Alexey Tsvetkov</atom:name>
 			<atom:uri>https://twitter.com/tsvtkv</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 9, Part 2: Gradle, Buck and Bazel with Alexey Tsvetkov</h1>
 
@@ -709,7 +709,7 @@
 			<li><a href="http://fragmentedpodcast.com/episodes/68/">Fragmented Podcast, Episode 68: Talking Buck with Uber engineer Gautam Korlam</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.10.mp3</guid>
@@ -723,7 +723,7 @@
 			<atom:name>Dmitry Jemerov</atom:name>
 			<atom:uri>https://twitter.com/intelliyole</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from JetBrains</h1>
 
@@ -770,7 +770,7 @@
 			<li><a href="http://kotlinlang.org/">Official Kotlin website with photo of lighthouse on Kotlin island</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3</guid>
@@ -784,7 +784,7 @@
 			<atom:name>Artur Dryomov</atom:name>
 			<atom:uri>https://github.com/ming13</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 11: Migration to RxJava 2 with Artur Dryomov from Juno</h1>
 
@@ -836,7 +836,7 @@
 			<li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3</guid>
@@ -850,7 +850,7 @@
 			<atom:name>Christian Bahl</atom:name>
 			<atom:uri>https://twitter.com/christian_bahl</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 12: Instant Apps with Lukas Olsen and Christian Bahl</h1>
 
@@ -901,7 +901,7 @@
 			</ul>
 
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3</guid>
@@ -915,7 +915,7 @@
 			<atom:name>Eric Kuck</atom:name>
 			<atom:uri>https://twitter.com/eric_kuck</atom:uri>
 		</atom:contributor>
-		<itunes:summary>
+		<content:encoded>
 			<![CDATA[
 			<h1>Episode 13: Conductor with Eric Kuck</h1>
 
@@ -961,7 +961,7 @@
 			<li><a href="https://github.com/EricKuck/ConductorGlideDemo">Demo of Glide integration with Controller LifecycleListener</a></li>
 			</ul>
 			]]>
-		</itunes:summary>
+		</content:encoded>
 	</item>
 </channel>
 </rss>

--- a/feed.rss
+++ b/feed.rss
@@ -46,6 +46,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
+		<description>In this episode we talked about software architecture on Android. We covered: MVC, MVVM, MVVMC, MVP, Flux and Cycle.js (a.k.a. Model-View-Intent)</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 1: Architecture of modern Android apps</h1>
@@ -104,6 +105,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
+		<description>In this episode we talked about testing in Android Development. We covered: Unit testing, Integration testing and Functional (UI) testing as well as Robolectric, Android Instrumentation API, UI Automator, Espresso, Robotium, Appium, JUnit, AssertJ, Thruth, Spock, Spek, and some questions from out listeners.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 2: Testing</h1>
@@ -170,6 +172,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
+		<description>In this episode we talked about RxJava. We covered: the history and the current state of RxJava as well as David Karnok's background and his earlier implementation of Reactive Extensions for JVM.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 3, Part 1: RxJava with its core developer David Karnok</h1>
@@ -216,6 +219,7 @@
 			<atom:uri>http://artemzin.com/</atom:uri>
 			<atom:email>artem.zinnatullin@gmail.com</atom:email>
 		</atom:author>
+		<description>We continue the RxJava discussion and go technical on Schedulers, subscribeOn and observeOn.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 3, Part 2: RxJava tech details with its core developer David Karnok</h1>
@@ -257,6 +261,7 @@
 			<atom:name>Chris Lacy</atom:name>
 			<atom:uri>https://twitter.com/chrismlacy</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked about Indie Development. Covering: How to get started, project management, testing and Continuous Integration, designing without being a designer and Play Store/IAP and subscriptions.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 4: Indie Development</h1>
@@ -317,6 +322,7 @@
 			<atom:name>Joe Birch</atom:name>
 			<atom:uri>http://hitherejoe.com/</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked about Android TV. We covered: Leanback Library, MVP Pattern to share code the Recommendation System and what's new in Android Nougat for Android TV</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 5: Android TV</h1>
@@ -374,6 +380,7 @@
 			<atom:name>Fernando Cejas</atom:name>
 			<atom:uri>http://fernandocejas.com/</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked about Continuous Integration and Continuous Delivery.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 6, Part1: Continuous Integration (CI) &amp; Continuous Delivery (CD)</h1>
@@ -428,6 +435,7 @@
 			<atom:name>Fernando Cejas</atom:name>
 			<atom:uri>http://fernandocejas.com/</atom:uri>
 		</atom:contributor>
+		<description>We continue the Continuous Integration and Continuous Delivery discussion.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 6, Part2: Continuous Integration (CI) &amp; Continuous Delivery (CD) with Fernando Cejas from SoundCloud</h1>
@@ -482,6 +490,7 @@
 			<atom:name>Felipe Lima</atom:name>
 			<atom:uri>https://medium.com/@felipecsl</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked about React Native, a cross platform solution to build native mobile apps using JavaScript and React, and how React Native is used at Airbnb.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 7: React Native with Felipe Lima from Airbnb</h1>
@@ -537,6 +546,7 @@
 			<atom:name>Paco Estevez</atom:name>
 			<atom:uri>http://www.pacoworks.com/</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked about Functional Programming and how Paco Estevez applies Functional Programming in his android apps.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 8: Damn Functional Programming with Paco Estevez</h1>
@@ -602,6 +612,7 @@
 			<atom:name>Alexey Tsvetkov</atom:name>
 			<atom:uri>https://twitter.com/tsvtkv</atom:uri>
 		</atom:contributor>
+		<description>In this episode we talked with Alexey Tsvetkov who is part of the Kotlin team at jetbrains about Kotlin's gradle plugin, compilers and build systems in general.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</h1>
@@ -668,6 +679,7 @@
 			<atom:name>Alexey Tsvetkov</atom:name>
 			<atom:uri>https://twitter.com/tsvtkv</atom:uri>
 		</atom:contributor>
+		<description>We continue our discussion with Alexey Tsvetkov talking about build systems for android development.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 9, Part 2: Gradle, Buck and Bazel with Alexey Tsvetkov</h1>
@@ -723,6 +735,7 @@
 			<atom:name>Dmitry Jemerov</atom:name>
 			<atom:uri>https://twitter.com/intelliyole</atom:uri>
 		</atom:contributor>
+		<description>We've talked to Dmitry Jemerov from Kotlin team at JetBrains about some language design decisions made in Kotlin.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from JetBrains</h1>
@@ -784,6 +797,7 @@
 			<atom:name>Artur Dryomov</atom:name>
 			<atom:uri>https://github.com/ming13</atom:uri>
 		</atom:contributor>
+		<description>We've talked to Artur about Juno's way to migrate their Android Riders App from RxJava 1 to RxJava 2.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 11: Migration to RxJava 2 with Artur Dryomov from Juno</h1>
@@ -850,6 +864,7 @@
 			<atom:name>Christian Bahl</atom:name>
 			<atom:uri>https://twitter.com/christian_bahl</atom:uri>
 		</atom:contributor>
+		<description>Hannes chatted with his coworkes Lukas and Christian about Instant Apps, AMP pages and more.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 12: Instant Apps with Lukas Olsen and Christian Bahl</h1>
@@ -915,6 +930,7 @@
 			<atom:name>Eric Kuck</atom:name>
 			<atom:uri>https://twitter.com/eric_kuck</atom:uri>
 		</atom:contributor>
+		<description>In this episode we chatted with Eric Kuck about Conductor, a framework created by Eric as alternative to Fragments.</description>
 		<content:encoded>
 			<![CDATA[
 			<h1>Episode 13: Conductor with Eric Kuck</h1>

--- a/feed.rss
+++ b/feed.rss
@@ -31,6 +31,7 @@
 	<itunes:image href="https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/logo.png"/>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_1/The.Context.episode.1.mp3</guid>
+		<itunes:title>Architecture of modern Android apps</itunes:title>
 		<title>Episode 1, Architecture of modern Android apps with Hannes Dorfmann</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_1.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/1"/>
@@ -90,6 +91,7 @@
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_2/The.Context.episode.2.mp3</guid>
+		<itunes:title>Testing</itunes:title>
 		<title>Episode 2, Testing with Mike Evans</title>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/17"/>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_2.md</link>
@@ -157,6 +159,7 @@
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3</guid>
+		<itunes:title>RxJava</itunes:title>
 		<title>Episode 3, Part 1: RxJava with its core developer David Karnok</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_1.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25"/>
@@ -204,6 +207,7 @@
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_2/The.Context.episode.3.Part2.mp3</guid>
+		<itunes:title>RxJava</itunes:title>
 		<title>Episode 3, Part 2: RxJava tech details with its core developer David Karnok</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_2.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25"/>
@@ -251,6 +255,7 @@
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_4/The.Context.episode.4.mp3</guid>
+		<itunes:title>Indie Development</itunes:title>
 		<title>Episode 4: Indie Development with Chris Lacy</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_4.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/36"/>
@@ -312,6 +317,7 @@
 	</item>
 	<item>
 		<guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_5/The.Context.episode.5.mp3</guid>
+		<itunes:title>Android TV</itunes:title>
 		<title>Episode 5: Android TV with Joe Birch</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_5.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/45"/>
@@ -370,6 +376,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part1.mp3</guid>
+		<itunes:title>Continuous Integration and Continuous Delivery</itunes:title>
 		<title>Episode 6, Part1: Continuous Integration (CI) and Continuous Delivery (CD) with Fernando Cejas from SoundCloud</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_6_part1.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/49"/>
@@ -425,6 +432,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part2.mp3</guid>
+		<itunes:title>Continuous Integration and Continuous Delivery</itunes:title>
 		<title>Episode 6, Part2: Continuous Integration (CI) and Continuous Delivery (CD) with Fernando Cejas from SoundCloud (&amp; EVERYTHING &amp; LIFE)</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_6_part2.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/52"/>
@@ -480,6 +488,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3</guid>
+		<itunes:title>React Native</itunes:title>
 		<title>Episode 7: React Native with Felipe Lima from Airbnb</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_7.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/55"/>
@@ -536,6 +545,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3</guid>
+		<itunes:title>Damn Functional Programming</itunes:title>
 		<title>Episode 8: Damn Functional Programming with Paco Estevez</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_8.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57"/>
@@ -602,6 +612,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part1.mp3</guid>
+		<itunes:title>Kotlin Gradle Plugin, Compilers and Build Systems</itunes:title>
 		<title>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_9_Part1.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57"/>
@@ -669,6 +680,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part2.mp3</guid>
+		<itunes:title>Gradle, Buck and Bazel</itunes:title>
 		<title>Episode 9, Part 2: Gradle, Buck and Bazel with Alexey Tsvetkov</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_9_Part2.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/66"/>
@@ -725,6 +737,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.10.mp3</guid>
+		<itunes:title>Kotlin Language Design Nitpicking</itunes:title>
 		<title>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from JetBrains</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_10.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/68"/>
@@ -787,6 +800,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3</guid>
+		<itunes:title>Migration to RxJava 2</itunes:title>
 		<title>Episode 11: Migration to RxJava 2 with Artur Dryomov from Juno</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_11.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/71"/>
@@ -854,6 +868,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3</guid>
+		<itunes:title>Instant Apps</itunes:title>
 		<title>Episode 12: Instant Apps with Lukas Olsen and Christian Bahl</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_12.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/74"/>
@@ -926,6 +941,7 @@
 	</item>
 	<item>
 		<guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3</guid>
+		<itunes:title>Conductor</itunes:title>
 		<title>Episode 13: Conductor with Eric Kuck</title>
 		<link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_13.md</link>
 		<atom:link rel="replies" type="text/html" href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/76"/>

--- a/feed.rss
+++ b/feed.rss
@@ -864,6 +864,13 @@
 			<atom:name>Christian Bahl</atom:name>
 			<atom:uri>https://twitter.com/christian_bahl</atom:uri>
 		</atom:contributor>
+		<atom:contributor>
+			<atom:name>Lukas Olsen</atom:name>
+		</atom:contributor>
+		<atom:author>
+			<atom:name>Hannes Dorfmann</atom:name>
+			<atom:uri>http://hannesdorfmann.com/</atom:uri>
+		</atom:author>
 		<description>Hannes chatted with his coworkes Lukas and Christian about Instant Apps, AMP pages and more.</description>
 		<content:encoded>
 			<![CDATA[
@@ -904,7 +911,6 @@
 
 			<ul>
 			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
 			</ul>
 
 			<h4>Additional links:</h4>
@@ -930,6 +936,14 @@
 			<atom:name>Eric Kuck</atom:name>
 			<atom:uri>https://twitter.com/eric_kuck</atom:uri>
 		</atom:contributor>
+		<atom:author>
+			<atom:name>Hannes Dorfmann</atom:name>
+			<atom:uri>http://hannesdorfmann.com/</atom:uri>
+		</atom:author>
+		<atom:author>
+			<atom:name>Artur Dryomov</atom:name>
+			<atom:uri>https://github.com/ming13</atom:uri>
+		</atom:author>
 		<description>In this episode we chatted with Eric Kuck about Conductor, a framework created by Eric as alternative to Fragments.</description>
 		<content:encoded>
 			<![CDATA[

--- a/show_notes/Episode_12.md
+++ b/show_notes/Episode_12.md
@@ -30,7 +30,6 @@ Hannes chatted with his coworkes Lukas and Christian about Instant Apps. Unfortu
 #### Hosts:
 
   - Hannes Dorfmann [@sockeqwe](https://twitter.com/sockeqwe), [personal blog](http://hannesdorfmann.com), [GitHub](https://github.com/sockeqwe)
-  - Artem Zinnatullin [@artem_zin](https://twitter.com/artem_zin), [personal blog](http://artemzin.com), [GitHub](https://github.com/artem-zinnatullin)
 
 #### Additional links:
 


### PR DESCRIPTION
I've made some more changed to the feed to better comply with the specs.

The Apple `summary` tag should be plain text, so I've changed it to `encoded` from `content`. I've added some plain text `description`s that iTunes will fall back to certain situations. Amended the `author` information for the latest 2 episodes. And I've added the new Apple `title` tag, based on the updated spec [draft](http://podcasts.apple.com/resources/spec/ApplePodcastsSpecUpdatesiOS11.pdf), potentially `episode` numbers should be adopted as well, but since you have multiple parts to some episodes I don't know how to handle them.