### PR TITLE
Replace current feed with generated one.

### DIFF
--- a/feed.rss
+++ b/feed.rss
@@ -1,1552 +1,1200 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>The Context #androiddev</title>
+    <description>Talks about Android development and related topics.</description>
+    <language>en</language>
     <link>https://github.com/artem-zinnatullin/TheContext-Podcast</link>
-    <description>New Podcast about Android Development</description>
-    <language>en-us</language>
-    <atom:link href="https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/feed.rss" rel="self" type="application/rss+xml" />
-    <lastBuildDate>Wed, 1 August 2018 09:36:00 EST</lastBuildDate>
-    <itunes:owner>
-      <itunes:email>artem.zinnatullin@gmail.com</itunes:email>
-      <itunes:name>Artem Zinnatullin</itunes:name>
-    </itunes:owner>
-    <atom:author>
-      <atom:name>Artem Zinnatullin</atom:name>
-      <atom:uri>http://artemzin.com/</atom:uri>
-      <atom:email>artem.zinnatullin@gmail.com</atom:email>
-    </atom:author>
-    <atom:author>
-      <atom:name>Hannes Dorfmann</atom:name>
-      <atom:uri>http://hannesdorfmann.com/</atom:uri>
-    </atom:author>
-    <itunes:author>Artem Zinnatullin</itunes:author>
+    <lastBuildDate>Sun, 13 Jan 2019 17:04:34 +0000</lastBuildDate>
+    <itunes:image href="https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/logo.png"/>
     <itunes:explicit>no</itunes:explicit>
-    <itunes:keywords>android,androiddev,context,development,software</itunes:keywords>
-    <itunes:subtitle>New Android Developers Podcast</itunes:subtitle>
-    <itunes:summary>The Context is a podcast about Android Development</itunes:summary>
     <itunes:category text="Technology">
-      <itunes:category text="Software How-To" />
+      <itunes:category text="Software How-To"/>
     </itunes:category>
-    <itunes:image href="https://raw.githubusercontent.com/artem-zinnatullin/TheContext-Podcast/master/logo.png" />
+    <itunes:owner>
+      <itunes:name>Artem Zinnatullin</itunes:name>
+      <itunes:email>artem.zinnatullin@gmail.com</itunes:email>
+    </itunes:owner>
+    <itunes:author>Artem Zinnatullin, Hannes Dorfmann, Artur Dryomov</itunes:author>
     <item>
+      <title>Episode 1: Architecture of modern Android apps</title>
+      <description>In this episode we have talked about software architecture on Android.</description>
+      <pubDate>Thu, 04 Feb 2016 20:04:07 +0000</pubDate>
       <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_1/The.Context.episode.1.mp3</guid>
-      <title>Episode 1, Architecture of modern Android apps with Hannes Dorfmann</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/1" rel="replies" type="text/html" />
-      <itunes:duration>57:55</itunes:duration>
-      <pubDate>Thu, 04 Feb 2016 20:04:07 PST</pubDate>
-      <enclosure length="83400224" type="audio/mpeg" url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_1/The.Context.episode.1.mp3" />
-      <atom:contributor>
-        <atom:name>Hannes Dorfmann</atom:name>
-        <atom:uri>http://hannesdorfmann.com/</atom:uri>
-      </atom:contributor>
-      <atom:author>
-        <atom:name>Artem Zinnatullin</atom:name>
-        <atom:uri>http://artemzin.com/</atom:uri>
-        <atom:email>artem.zinnatullin@gmail.com</atom:email>
-      </atom:author>
-      <itunes:summary><![CDATA[<h1>Episode 1: Architecture of modern Android apps</h1>
-
-
-
-			<p>In this episode we have talked about software architecture on Android. We have covered:</p>
-
-			<ul>
-				<li>MVC</li>
-				<li>MVVM</li>
-				<li>MVVMC</li>
-				<li>MVP</li>
-				<li><a href="https://facebook.github.io/flux/docs/overview.html">Flux</a></li>
-				<li><a href="http://cycle.js.org/">Cycle.js</a> (a.k.a. Model-View-Intent)</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com/">personal blog</a>, <a href="https://github.com/sockeqwe/">GitHub</a></p>
-
-			<p>Open Source projects from Hannes:</p>
-
-			<ul>
-				<li><a href="https://github.com/sockeqwe/mosby">Mosby</a></li>
-				<li><a href="https://github.com/sockeqwe/sqlbrite-dao">SQLBrite-DAO</a></li>
-				<li><a href="https://github.com/sockeqwe/fragmentargs">FragmentArgs</a></li>
-				<li><a href="https://github.com/sockeqwe/ParcelablePlease">ParcelablePlease</a></li>
-			</ul>
-
-			<h4>Additional links</h4>
-
-			<ul>
-				<li><a href="https://github.com/google/auto/issues/268">AutoValue split into 2 jars issue</a></li>
-				<li><a href="https://google.github.io/dagger/testing.html">Dagger 2 document about testing</a></li>
-				<li><a href="https://github.com/rheinfabrik/android-mvvm-example">Clean MVVM example</a></li>
-				<li><a href="https://github.com/google/dagger/issues/298">Gradle's incremental build issue with annotation processing</a></li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_1/The.Context.episode.1.mp3" length="83400224" type="audio/mpeg"/>
+      <itunes:duration>00:57:55</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked about software architecture on Android.</p>
+          <p>We covered:</p>
+          <ul>
+          <li>MVC</li>
+          <li>MVVM</li>
+          <li>MVVMC</li>
+          <li>MVP</li>
+          <li><a href="https://facebook.github.io/flux/docs/overview.html">Flux</a></li>
+          <li><a href="http://cycle.js.org/">Cycle.js</a> (a.k.a. Model-View-Intent)</li>
+          </ul>
+          <p>Open Source projects from Hannes:</p>
+          <ul>
+          <li><a href="https://github.com/sockeqwe/mosby">Mosby</a></li>
+          <li><a href="https://github.com/sockeqwe/sqlbrite-dao">SQLBrite-DAO</a></li>
+          <li><a href="https://github.com/sockeqwe/fragmentargs">FragmentArgs</a></li>
+          <li><a href="https://github.com/sockeqwe/ParcelablePlease">ParcelablePlease</a></li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/google/auto/issues/268">AutoValue split into 2 jars issue</a></li>
+          <li><a href="https://google.github.io/dagger/testing.html">Dagger 2 document about testing</a></li>
+          <li><a href="https://github.com/rheinfabrik/android-mvvm-example">Clean MVVM example</a></li>
+          <li><a href="https://github.com/google/dagger/issues/298">Gradle's incremental build issue with annotation processing</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/1">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 2: Testing</title>
+      <description>In this episode we have talked about testing in Android Development.</description>
+      <pubDate>Fri, 26 Feb 2016 06:25:07 +0000</pubDate>
       <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_2/The.Context.episode.2.mp3</guid>
-      <title>Episode 2, Testing with Mike Evans</title>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/17" rel="replies" type="text/html" />
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_2.md</link>
-      <itunes:duration>1:42:01</itunes:duration>
-      <pubDate>Fri, 26 Feb 2016 06:25:07 EST</pubDate>
-      <enclosure length="146938181" type="audio/mpeg" url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_2/The.Context.episode.2.mp3" />
-      <atom:contributor>
-        <atom:name>Mike Evans</atom:name>
-        <atom:uri>http://michaelevans.org/</atom:uri>
-      </atom:contributor>
-      <atom:author>
-        <atom:name>Artem Zinnatullin</atom:name>
-        <atom:uri>http://artemzin.com/</atom:uri>
-        <atom:email>artem.zinnatullin@gmail.com</atom:email>
-      </atom:author>
-      <itunes:summary><![CDATA[<h1>Episode 2: Testing</h1>
-
-			<p>In this episode we have talked about testing in Android Development. We have covered:</p>
-
-			<ul>
-				<li><a href="https://en.wikipedia.org/wiki/Unit_testing">Unit testing</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Integration_testing">Integration testing</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Functional_testing">Functional (UI) testing</a></li>
-				<li><a href="http://robolectric.org">Robolectric</a></li>
-				<li><a href="http://developer.android.com/tools/testing/testing_android.html#Instrumentation">Android Instrumentation API</a></li>
-				<li><a href="http://developer.android.com/tools/testing-support-library/index.html#UIAutomator">UI Automator</a></li>
-				<li><a href="http://developer.android.com/tools/testing-support-library/index.html#Espresso">Espresso</a></li>
-				<li><a href="https://github.com/RobotiumTech/robotium">Robotium</a></li>
-				<li><a href="http://appium.io">Appium</a></li>
-				<li><a href="http://junit.org">JUnit</a></li>
-				<li><a href="http://joel-costigliola.github.io/assertj/">AssertJ</a></li>
-				<li><a href="https://github.com/google/truth">Thruth</a></li>
-				<li><a href="https://github.com/spockframework/spock">Spock</a></li>
-				<li><a href="https://github.com/JetBrains/spek">Spek</a></li>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/15">Questions asked by listeners</a>.</li>
-			</ul>
-
-			<h4>Host:</h4>
-
-			<p>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></p>
-
-			<h4>Guest:</h4>
-
-			<p>Mike Evans <a href="https://twitter.com/m_evans10">@m_evans10</a>, <a href="http://michaelevans.org">personal blog</a>, <a href="https://github.com/MichaelEvans">GitHub</a></p>
-
-			<p>Open Source projects from Mike:</p>
-
-			<ul>
-				<li><a href="https://github.com/MichaelEvans/Aftermath">Aftermath</a></li>
-				<li><a href="https://github.com/MichaelEvans/ColorArt">ColorArt</a> </li>
-			</ul>
-
-			<p>Additional links:</p>
-
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/qualitymatters">#qualitymatters</a></li>
-				<li><a href="https://github.com/JakeWharton/u2020">U2020</a></li>
-				<li><a href="http://jakewharton.com/android-needs-a-simulator/">Android Needs A Simulator, Not An Emulator</a></li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_2/The.Context.episode.2.mp3" length="146938181" type="audio/mpeg"/>
+      <itunes:duration>01:42:01</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked about testing in Android Development.</p>
+          <p>In this episode we have talked about testing in Android Development. We have covered:</p>
+          <ul>
+          <li><a href="https://en.wikipedia.org/wiki/Unit_testing">Unit testing</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Integration_testing">Integration testing</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Functional_testing">Functional (UI) testing</a></li>
+          <li><a href="http://robolectric.org">Robolectric</a></li>
+          <li><a href="http://developer.android.com/tools/testing/testing_android.html#Instrumentation">Android Instrumentation API</a></li>
+          <li><a href="http://developer.android.com/tools/testing-support-library/index.html#UIAutomator">UI Automator</a></li>
+          <li><a href="http://developer.android.com/tools/testing-support-library/index.html#Espresso">Espresso</a></li>
+          <li><a href="https://github.com/RobotiumTech/robotium">Robotium</a></li>
+          <li><a href="http://appium.io">Appium</a></li>
+          <li><a href="http://junit.org">JUnit</a></li>
+          <li><a href="http://joel-costigliola.github.io/assertj/">AssertJ</a></li>
+          <li><a href="https://github.com/google/truth">Thruth</a></li>
+          <li><a href="https://github.com/spockframework/spock">Spock</a></li>
+          <li><a href="https://github.com/JetBrains/spek">Spek</a></li>
+          <li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/15">Questions asked by listeners</a>.</li>
+          </ul>
+          <p>Open Source projects from Mike:</p>
+          <ul>
+          <li><a href="https://github.com/MichaelEvans/Aftermath">Aftermath</a></li>
+          <li><a href="https://github.com/MichaelEvans/ColorArt">ColorArt</a></li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/artem-zinnatullin/qualitymatters">#qualitymatters</a></li>
+          <li><a href="https://github.com/JakeWharton/u2020">U2020</a></li>
+          <li><a href="http://jakewharton.com/android-needs-a-simulator/">Android Needs A Simulator, Not An Emulator</a></li>
+          <li><a href="http://artemzin.com/blog/minsdk-without-flavors/">minSdkVersion for multiDex without flavors</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Mike Evans: <a href="https://twitter.com/m_evans10">Twitter</a>, <a href="https://github.com/MichaelEvans">GitHub</a>, <a href="http://michaelevans.org">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/17">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3</guid>
       <title>Episode 3, Part 1: RxJava with its core developer David Karnok</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25" rel="replies" type="text/html" />
-      <itunes:duration>44:12</itunes:duration>
-      <pubDate>Wed, 9 March 2016 00:00:07 EST</pubDate>
-      <enclosure length="63658598" type="audio/mpeg" url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3" />
-      <atom:contributor>
-        <atom:name>David Karnok</atom:name>
-        <atom:uri>http://akarnokd.blogspot.com/</atom:uri>
-      </atom:contributor>
-      <atom:author>
-        <atom:name>Artem Zinnatullin</atom:name>
-        <atom:uri>http://artemzin.com/</atom:uri>
-        <atom:email>artem.zinnatullin@gmail.com</atom:email>
-      </atom:author>
-      <itunes:summary><![CDATA[<h1>Episode 3, Part 1: RxJava with its core developer David Karnok</h1>
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/24">Discussion before the episode</a></li>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this part of the episode we have talked about RxJava. We have covered:</p>
-
-			<ul>
-				<li>Past of RxJava</li>
-				<li>Background of David Karnok and his earlier implementation of Reactive Extensions for JVM</li>
-				<li>Current state of the RxJava development</li>
-				<li>Reactive Streams specification</li>
-				<li>JDK 9 Flow API</li>
-				<li>RxJava v2 and Android compatibility</li>
-			</ul>
-
-			<h4>Host:</h4>
-
-			<p>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></p>
-
-			<h4>Guest:</h4>
-
-			<p>David Karnok <a href="https://twitter.com/akarnokd">@akarnokd</a>, <a href="http://akarnokd.blogspot.com">personal blog</a>, <a href="https://github.com/akarnokd">GitHub</a></p>]]></itunes:summary>
+      <description>In this part of the episode we have talked about RxJava.</description>
+      <pubDate>Wed, 09 Mar 2016 00:00:07 +0000</pubDate>
+      <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3</guid>
+      <enclosure url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_1/The.Context.episode.3.Part1.mp3" length="63658598" type="audio/mpeg"/>
+      <itunes:duration>00:44:12</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this part of the episode we have talked about RxJava.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>Past of RxJava</li>
+          <li>Background of David Karnok and his earlier implementation of Reactive Extensions for JVM</li>
+          <li>Current state of the RxJava development</li>
+          <li>Reactive Streams specification</li>
+          <li>JDK 9 Flow API</li>
+          <li>RxJava v2 and Android compatibility</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>David Karnok: <a href="https://twitter.com/akarnokd">Twitter</a>, <a href="https://github.com/akarnokd">GitHub</a>, <a href="http://akarnokd.blogspot.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 3, Part 2: RxJava with its core developer David Karnok</title>
+      <description>In the second part of the episode we continued the discussion about RxJava.</description>
+      <pubDate>Wed, 16 Mar 2016 20:52:07 +0000</pubDate>
       <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_2/The.Context.episode.3.Part2.mp3</guid>
-      <title>Episode 3, Part 2: RxJava tech details with its core developer David Karnok</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25" rel="replies" type="text/html" />
-      <itunes:duration>37:30</itunes:duration>
-      <pubDate>Wed, 16 March 2016 20:52:07 EST</pubDate>
-      <enclosure length="54085821" type="audio/mpeg" url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_2/The.Context.episode.3.Part2.mp3" />
-      <atom:contributor>
-        <atom:name>David Karnok</atom:name>
-        <atom:uri>http://akarnokd.blogspot.com/</atom:uri>
-      </atom:contributor>
-      <atom:author>
-        <atom:name>Artem Zinnatullin</atom:name>
-        <atom:uri>http://artemzin.com/</atom:uri>
-        <atom:email>artem.zinnatullin@gmail.com</atom:email>
-      </atom:author>
-      <itunes:summary><![CDATA[<h1>Episode 3, Part 2: RxJava tech details with its core developer David Karnok</h1>
-
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/24">Discussion before the episode</a></li>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25">Discussion after the episode</a></li>
-			</ul>
-
-			<p>More technical questions about RxJava. We have covered:</p>
-
-			<ul>
-				<li><code>Schedulers.computation()</code> in RxJava</li>
-				<li>Schedulers in RxJava</li>
-				<li><code>subscribeOn()</code> and <code>observeOn()</code></li>
-				<li>Testing code with RxJava</li>
-				<li>Extending the <code>Observable</code></li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>David Karnok <a href="https://twitter.com/akarnokd">@akarnokd</a>, <a href="http://akarnokd.blogspot.com">personal blog</a>, <a href="https://github.com/akarnokd">GitHub</a></p>
-
-			<h4>Host:</h4>
-
-			<p>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></p>]]></itunes:summary>
+      <enclosure url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_3_Part_2/The.Context.episode.3.Part2.mp3" length="63658598" type="audio/mpeg"/>
+      <itunes:duration>00:37:30</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In the second part of the episode we continued the discussion about RxJava.</p>
+          <p>More technical questions about RxJava. We have covered:</p>
+          <ul>
+          <li><code>Schedulers.computation()</code> in RxJava</li>
+          <li>Schedulers in RxJava</li>
+          <li><code>subscribeOn()</code> and <code>observeOn()</code></li>
+          <li>Testing code with RxJava</li>
+          <li>Extending the <code>Observable</code></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>David Karnok: <a href="https://twitter.com/akarnokd">Twitter</a>, <a href="https://github.com/akarnokd">GitHub</a>, <a href="http://akarnokd.blogspot.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/25">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 4: Indie Development</title>
+      <description>In this episode we have talked about Indie Development.</description>
+      <pubDate>Sun, 01 May 2016 05:44:07 +0000</pubDate>
       <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_4/The.Context.episode.4.mp3</guid>
-      <title>Episode 4: Indie Development with Chris Lacy</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_4.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/36" rel="replies" type="text/html" />
-      <itunes:duration>1:07:44</itunes:duration>
-      <pubDate>Sun, 1 May 2016 5:44:07 EST</pubDate>
-      <enclosure length="97552116" type="audio/mpeg" url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_4/The.Context.episode.4.mp3" />
-      <atom:contributor>
-        <atom:name>Chris Lacy</atom:name>
-        <atom:uri>https://twitter.com/chrismlacy</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 4: Indie Development</h1>
-
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/36">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked about Indie Development. We have covered:</p>
-
-			<ul>
-				<li>How to get started in Indie development</li>
-				<li>Project management as single developer</li>
-				<li>Testing and Continuous Integration</li>
-				<li>How does an Indie developer decides which libraries or technologies to use?</li>
-				<li>Designing without being a designer</li>
-				<li>Play Store, in app purchases and subscriptions</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Chris Lacy <a href="https://twitter.com/chrismlacy">@chrismlacy</a></p>
-
-			<p>Apps published by Chris Lacy on <a href="
-			https://play.google.com/store/apps/developer?id=Chris+Lacy">Google Play Store</a>:
-			<ul>
-				<li><a href="https://play.google.com/store/apps/details?id=com.actionlauncher.playstore">Action Launcher 3</a></li>
-				<li><a href="https://play.google.com/store/apps/details?id=com.chrislacy.actionlauncher.pro">Action Launcher 2</a></li>
-				<li><a href="https://play.google.com/store/apps/details?id=com.tweetlanes.android">Tweet Lanes</a></p></li>
-			</ul>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<p>Additional links:</p>
-
-			<ul>
-				<li><a href="http://theblerg.net/">The Blerg</a>: Chris Lacy's podcast</li>
-				<li><a href="http://theblerg.net/post/2015/08/05/ive-sold-link-bubble-tappath-and-all-related-assets">Chris blog post about selling Link Bubble</a></li>
-				<li><a href="https://github.com/brave/browser-android">Link Bubble</a> has been open sourced</li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_4/The.Context.episode.4.mp3" length="97552116" type="audio/mpeg"/>
+      <itunes:duration>01:07:44</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked about Indie Development.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>How to get started in Indie development</li>
+          <li>Project management as single developer</li>
+          <li>Testing and Continuous Integration</li>
+          <li>How does an Indie developer decides which libraries or technologies to use?</li>
+          <li>Designing without being a designer</li>
+          <li>Play Store, in app purchases and subscriptions</li>
+          </ul>
+          <p>Apps published by Chris Lacy on <a href="https://play.google.com/store/apps/developer?id=Chris+Lacy">Google Play Store</a>:</p>
+          <ul>
+          <li><a href="https://play.google.com/store/apps/details?id=com.actionlauncher.playstore">Action Launcher 3</a></li>
+          <li><a href="https://play.google.com/store/apps/details?id=com.chrislacy.actionlauncher.pro">Action Launcher 2</a></li>
+          <li><a href="https://play.google.com/store/apps/details?id=com.tweetlanes.android">Tweet Lanes</a></li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="http://theblerg.net/">the blerg</a>: Chris Lacy's podcast</li>
+          <li><a href="http://theblerg.net/post/2015/08/05/ive-sold-link-bubble-tappath-and-all-related-assets">Chris blog post about selling Link Bubble</a></li>
+          <li><a href="https://github.com/brave/browser-android">Link Bubble</a> has been open sourced</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Chris Lacy: <a href="https://twitter.com/chrismlacy">Twitter</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/36">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 5: Android TV </title>
+      <description>In episode 5 we talked to Joe Birch about Android TV.</description>
+      <pubDate>Fri, 01 Jul 2016 19:06:00 +0000</pubDate>
       <guid>https://github.com/artem-zinnatullin/TheContext-Podcast/releases/download/Episode_5/The.Context.episode.5.mp3</guid>
-      <title>Episode 5: Android TV with Joe Birch</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_5.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/45" rel="replies" type="text/html" />
-      <itunes:duration>49:22</itunes:duration>
-      <pubDate>Fri, 1 July 2016 19:06:00 EST</pubDate>
-      <enclosure length="47396669" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.5.mp3" />
-      <atom:contributor>
-        <atom:name>Joe Birch</atom:name>
-        <atom:uri>http://hitherejoe.com/</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 5: Android TV</h1>
-
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/45">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked about Android TV. We have covered:</p>
-
-			<ul>
-				<li>What is Android TV</li>
-				<li>Leanback Library</li>
-				<li>MVP Pattern to share code between Phone and Android TV App</li>
-				<li>Android TV Recommendation System</li>
-				<li>What's new in Android Nougat for Android TV</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Joe Birch <a href="https://twitter.com/hitherejoe">@hitherejoe</a></p> <a href="http://hitherejoe.com/">personal blog</a>, <a href="https://github.com/hitherejoe">GitHub</a>, <a href="http://medium.com/@hitherejoe">Medium</a>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<p>Additional links:</p>
-
-			<ul>
-				<li><a href="https://medium.com/exploring-android/introducing-bourbon-dribbble-android-mvp-and-a-common-code-module-1d332a4028b5">Bourbon</a>: Dribbble, Android, MVP and a Common-Code Module</li>
-				<li><a href="https://medium.com/exploring-android/vineyard-creating-an-android-tv-vine-app-e1480708b0a3">Vineyard</a>: Creating an Android TV Vine App</li>
-				<li><a href="https://medium.com/@hitherejoe/android-tv-chill-3ba9c413daef">Android TV & Chill</a>: A concept for what it would be like ordering fast-food on Android TV</li>
-				<li><a href="https://medium.com/@hitherejoe/code-life-d25d9178e4da">Code != Life</a>: On finding the balance between side-projects and headspace.</li>
-				<li><a href="https://medium.com/exploring-android/designing-for-android-tv-9fecd5cd0c8c">Designing for Android TV</a></li>
-				<li><a href="https://youtu.be/TxAbht2DkyU">Picture in Picture on Android TV</a></li>
-				<li><a href="https://play.google.com/store/apps/details?id=net.froemling.bombsquad">BombSquad</a>: A funny game Hannes has mentioned</li>
-				<li><a href="https://play.google.com/store/apps/details?id=net.froemling.bsremote">BombSquad Remote</a>: Use your phone as a controller for BombSquad</li>
-				<li><a href="https://youtu.be/qv-e1sV3gos">Bring your Android app to Android TV in minutes </a>: Google I/O 2016</li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.5.mp3" length="47396669" type="audio/mpeg"/>
+      <itunes:duration>00:49:22</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In episode 5 we talked to Joe Birch about Android TV.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>What is Android TV</li>
+          <li>Leanback Library</li>
+          <li>MVP Pattern to share code between Phone and Android TV App</li>
+          <li>Android TV Recommendation System</li>
+          <li>What's new in Android Nougat for Android TV</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://medium.com/exploring-android/introducing-bourbon-dribbble-android-mvp-and-a-common-code-module-1d332a4028b5">Bourbon</a>: Dribbble, Android, MVP and a Common-Code Module</li>
+          <li><a href="https://medium.com/exploring-android/vineyard-creating-an-android-tv-vine-app-e1480708b0a3">Vineyard</a>: Creating an Android TV Vine App</li>
+          <li><a href="https://medium.com/@hitherejoe/android-tv-chill-3ba9c413daef">Android TV &amp; Chill</a>: A concept for what it would be like ordering fast-food on Android TV</li>
+          <li><a href="https://medium.com/@hitherejoe/code-life-d25d9178e4da">Code != Life</a>: On finding the balance between side-projects and headspace</li>
+          <li><a href="https://medium.com/exploring-android/designing-for-android-tv-9fecd5cd0c8c">Designing for Android TV</a></li>
+          <li><a href="https://youtu.be/TxAbht2DkyU">Picture in Picture on Android TV</a></li>
+          <li><a href="https://play.google.com/store/apps/details?id=net.froemling.bombsquad">BombSquad</a>: A funny game Hannes has mentioned</li>
+          <li><a href="https://play.google.com/store/apps/details?id=net.froemling.bsremote">BombSquad Remote</a>: Use your phone as a controller for BombSquad</li>
+          <li><a href="https://youtu.be/qv-e1sV3gos">Bring your Android app to Android TV in minutes</a>: Google I/O 2016</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Joe Birch: <a href="https://twitter.com/hitherejoe">Twitter</a>, <a href="https://github.com/hitherejoe">GitHub</a>, <a href="https://joebirch.co">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/45">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 6, Part 1: Continuous Integration (CI) &amp; Continuous Delivery (CD)</title>
+      <description>In this episode we have talked about Continious Integration (CI) and Continuous Delivery (CD). Fernando Cejas gives us some insights how Soundcloud do CI and CD.</description>
+      <pubDate>Mon, 22 Aug 2016 07:00:00 +0000</pubDate>
       <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part1.mp3</guid>
-      <title>Episode 6, Part1: Continuous Integration (CI) and Continuous Delivery (CD) with
-                Fernando Cejas from
-                SoundCloud</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_6_part1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/49" rel="replies" type="text/html" />
-      <itunes:duration>43:14</itunes:duration>
-      <pubDate>Mon, 22 August 2016 7:00:00 EST</pubDate>
-      <enclosure length="62473519" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part1.mp3" />
-      <atom:contributor>
-        <atom:name>Fernando Cejas</atom:name>
-        <atom:uri>http://fernandocejas.com/</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 6, Part1: Continuous Integration (CI) &amp; Continuous Delivery (CD)</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/49">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked about Continuous Integration and Continuous Delivery. We have covered:</p>
-
-			<ul>
-			<li>Continuous Integration</li>
-			<li>Continuous Delivery</li>
-			<li>Pair Programming</li>
-			<li>Release Train</li>
-			<li>Soundcloud's CI &amp; CD Pipeline</li>
-			<li>Testing</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Fernando Cejas <a href="https://twitter.com/fernando_cejas">@fernando_cejas</a>, <a href="http://fernandocejas.com">personal blog</a>, <a href="https://github.com/android10">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://speakerdeck.com/android10/it-is-about-philosophy-culture-of-a-good-programmer-second-edition">Slides from Fernando's talk at MobileOptimized'2016 </a></li>
-
-			<li><a href="https://github.com/android10/Android-CleanArchitecture">Fernando's Clean Architecture sample on github</a></li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part1.mp3" length="62473519" type="audio/mpeg"/>
+      <itunes:duration>00:43:14</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked about Continious Integration (CI) and Continuous Delivery (CD). Fernando Cejas gives us some insights how Soundcloud do CI and CD.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>Continuous Integration</li>
+          <li>Continuous Delivery</li>
+          <li>Pair Programming</li>
+          <li>Release Train</li>
+          <li>Soundcloud's CI &amp; CD Pipeline</li>
+          <li>Testing</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://speakerdeck.com/android10/it-is-about-philosophy-culture-of-a-good-programmer-second-edition">Slides from Fernando's talk at MobileOptimized'2016 </a></li>
+          <li><a href="https://github.com/android10/Android-CleanArchitecture">Fernando's Clean Architecture</a> sample on github</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Fernando Cejas: <a href="https://twitter.com/fernando_cejas">Twitter</a>, <a href="https://github.com/android10">GitHub</a>, <a href="http://fernandocejas.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/49">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 6, Part 2: Continuous Integration (CI) &amp; Continuous Delivery (CD)</title>
+      <description>In this episode we have talked about Continious Integration (CI) and Continuous Delivery (CD). Fernando Cejas gives us some insights how Soundcloud do CI and CD.</description>
+      <pubDate>Wed, 31 Aug 2016 07:45:00 +0000</pubDate>
       <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part2.mp3</guid>
-      <title>Episode 6, Part2: Continuous Integration (CI) and Continuous Delivery (CD) with
-                Fernando Cejas from
-                SoundCloud (&amp; EVERYTHING &amp; LIFE)</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_6_part2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/52" rel="replies" type="text/html" />
-      <itunes:duration>45:55</itunes:duration>
-      <pubDate>Wed, 31 August 2016 07:45:00 EST</pubDate>
-      <enclosure length="66043032" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part2.mp3" />
-      <atom:contributor>
-        <atom:name>Fernando Cejas</atom:name>
-        <atom:uri>http://fernandocejas.com/</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 6, Part2: Continuous Integration (CI) &amp; Continuous Delivery (CD) with Fernando Cejas from SoundCloud</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/52">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked about Continuous Integration and Continuous Delivery. We have covered:</p>
-
-			<ul>
-				<li>UI Tests</li>
-				<li>Continuous Integration</li>
-				<li>Continuous Delivery</li>
-				<li>Soundcloud's CI &amp; CD Pipeline</li>
-				<li>Testing in general</li>
-				<li>EVERYTHING &amp; LIFE</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Fernando Cejas <a href="https://twitter.com/fernando_cejas">@fernando_cejas</a>, <a href="http://fernandocejas.com">personal blog</a>, <a href="https://github.com/android10">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="https://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-				<li><a href="https://speakerdeck.com/android10/it-is-about-philosophy-culture-of-a-good-programmer-second-edition">Slides from Fernando's talk at MobileOptimized'2016 </a></li>
-				<li><a href="https://github.com/android10/Android-CleanArchitecture">Fernando's Clean Architecture</a> sample on github</li>
-				<li><a href="http://hannesdorfmann.com/android/from-prefabricated-house-to-lego-house">From Prefab House to Lego House</a> - Blog post about depending on a shared library</li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.6.part2.mp3" length="66043032" type="audio/mpeg"/>
+      <itunes:duration>00:45:55</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked about Continious Integration (CI) and Continuous Delivery (CD). Fernando Cejas gives us some insights how Soundcloud do CI and CD.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>UI Tests</li>
+          <li>Continuous Integration</li>
+          <li>Continuous Delivery</li>
+          <li>Soundcloud's CI &amp; CD Pipeline</li>
+          <li>Testing in general</li>
+          <li>EVERYTHING &amp; LIFE</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://speakerdeck.com/android10/it-is-about-philosophy-culture-of-a-good-programmer-second-edition">Slides from Fernando's talk at MobileOptimized'2016 </a></li>
+          <li><a href="https://github.com/android10/Android-CleanArchitecture">Fernando's Clean Architecture</a> sample on github</li>
+          <li><a href="http://hannesdorfmann.com/android/from-prefabricated-house-to-lego-house">From Prefab House to Lego House</a> - Blog post about depending on a shared library</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Fernando Cejas: <a href="https://twitter.com/fernando_cejas">Twitter</a>, <a href="https://github.com/android10">GitHub</a>, <a href="http://fernandocejas.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/49">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3</guid>
       <title>Episode 7: React Native with Felipe Lima from Airbnb</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_7.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/55" rel="replies" type="text/html" />
-      <itunes:duration>52:41</itunes:duration>
-      <pubDate>Fri, 2 December 2016 17:00:00 EST</pubDate>
-      <enclosure length="75883752" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3" />
-      <atom:contributor>
-        <atom:name>Felipe Lima</atom:name>
-        <atom:uri>https://medium.com/@felipecsl</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 7: React Native with Felipe Lima from Airbnb</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/55">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked with Felipe Lima about React Native, a cross platform solution to build native mobile apps using JavaScript and React, and how React Native is used at Airbnb. We have covered:</p>
-
-			<ul>
-			<li>Advantages and Disadvantages of React Native</li>
-			<li>React Native build tools, IDE and debugging  </li>
-			<li>How to write your own custom component</li>
-			<li>Lifecycle, state restoration and process death in React Native apps</li>
-			<li>Integration and interaction with android system services</li>
-			<li>Sharing code with iOS</li>
-			<li>Usage for React Native in Airbnb's android and iOS app</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Felipe Lima <a href="https://twitter.com/felipecsl">@felipecsl</a>, <a href="https://medium.com/@felipecsl">personal blog</a>, <a href="http://felipecsl.com">personal website</a>, <a href="https://github.com/felipecsl">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://facebook.github.io/react-native/">React Native website</a></li>
-			<li><a href="https://medium.com/@felipecsl/thoughts-on-react-native-from-an-android-engineers-perspective-ea2bea5aa078#.k31212quk">Thoughts on React Native by Felipe</a> sample on github</li>
-			<li><a href="https://www.youtube.com/watch?v=npwa3ZmG9VQ">ReactiveConf 2016 (YouTube)</a> - Bridging the Gap: How to use React Native in existing large native code bases by Airbnb engineer Leland Richardson.</li>
-			</ul>]]></itunes:summary>
+      <description>In this episode we have talked with Felipe Lima about React Native, a cross platform solution to build native mobile apps using JavaScript and React, and how React Native is used at Airbnb.</description>
+      <pubDate>Fri, 02 Dec 2016 17:00:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.7.mp3" length="75883752" type="audio/mpeg"/>
+      <itunes:duration>00:52:41</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked with Felipe Lima about React Native, a cross platform solution to build native mobile apps using JavaScript and React, and how React Native is used at Airbnb.</p>
+          <p>In this episode we have talked with Felipe Lima about React Native, a cross platform solution to build native mobile apps using JavaScript and React, and how React Native is used at Airbnb. We have covered:</p>
+          <ul>
+          <li>Advantages and Disadvantages of React Native</li>
+          <li>React Native build tools, IDE and debugging</li>
+          <li>How to write your own custom component</li>
+          <li>Lifecycle, state restoration and process death in React Native apps</li>
+          <li>Integration and interaction with android system services</li>
+          <li>Sharing code with iOS</li>
+          <li>Usage for React Native in Airbnb's android and iOS app</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://facebook.github.io/react-native/">React Native website</a></li>
+          <li><a href="https://medium.com/@felipecsl/thoughts-on-react-native-from-an-android-engineers-perspective-ea2bea5aa078#.k31212quk">Thoughts on React Native by Felipe</a> sample on github</li>
+          <li><a href="https://www.youtube.com/watch?v=npwa3ZmG9VQ">ReactiveConf 2016 (YouTube)</a> - Bridging the Gap: How to use React Native in existing large native code bases by Airbnb engineer Leland Richardson.</li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Felipe Lima: <a href="https://twitter.com/felipecsl">Twitter</a>, <a href="https://github.com/felipecsl">GitHub</a>, <a href="https://medium.com/@felipecsl">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/55">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3</guid>
       <title>Episode 8: Damn Functional Programming with Paco Estevez</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_8.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57" rel="replies" type="text/html" />
+      <description>In this episode we have talked with Paco Estevez about Functional Programming and how he applies Functional Programming in his android apps.</description>
+      <pubDate>Thu, 02 Mar 2017 14:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3" length="66218024" type="audio/mpeg"/>
       <itunes:duration>01:08:56</itunes:duration>
-      <pubDate>Thu, 2 March 2017 14:30:00 EST</pubDate>
-      <enclosure length="66218024" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.8.mp3" />
-      <atom:contributor>
-        <atom:name>Paco Estevez</atom:name>
-        <atom:uri>http://www.pacoworks.com/</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 8: Damn Functional Programming with Paco Estevez</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked with Paco Estevez about Functional Programming and how he applies Functional Programming in his android apps. We have covered:</p>
-
-			<ul>
-			<li>Concepts of Functional Programming</li>
-			<li>Monads, Pure Functions, Immutability, Tuples, Union Types</li>
-			<li>Pattern Matching</li>
-			<li>Error Handling</li>
-			<li>Functional Reactive Programming with RxJava</li>
-			<li>Restoring state in Android apps</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Paco Estevez <a href="https://twitter.com/pacoworks">@pacoworks</a>, <a href="http://www.pacoworks.com">personal blog</a>, <a href="https://github.com/pakoito/">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<p>Talks, books and websites about Functional Programming:</p>
-
-			<ul>
-			<li><a href="http://www.braveclojure.com">Clojure for the Brave and True</a></li>
-			<li><a href="http://learnyouahaskell.com">Learn You a Haskell for Great Good</a></li>
-			<li><a href="https://fsharpforfunandprofit.com">F# for fun and profit</a></li>
-			<li><a href="https://speakerdeck.com/pakoito/about-memory-management-in-fully-reactive-apps">Talk by Paco about Memory Management in Fully Reactive Apps</a></li>
-			</ul>
-
-			<p>Some of Paco's open source libraries:</p>
-
-			<ul>
-			<li><a href="https://github.com/pakoito/Komprehensions">Komprehensions</a></li>
-			<li><a href="https://github.com/pakoito/RxSealedUnions2">RxSealedUnions</a></li>
-			<li><a href="https://github.com/pakoito/RxTuples2">RxTuples</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked with Paco Estevez about Functional Programming and how he applies Functional Programming in his android apps.</p>
+          <p>In this episode we have talked with Paco Estevez about Functional Programming and how he applies Functional Programming in his android apps. We have covered:</p>
+          <ul>
+          <li>Concepts of Functional Programming</li>
+          <li>Monads, Pure Functions, Immutability, Tuples, Union Types</li>
+          <li>Pattern Matching</li>
+          <li>Error Handling</li>
+          <li>Functional Reactive Programming with RxJava</li>
+          <li>Restoring state in Android apps</li>
+          </ul>
+          <p>Links:</p>
+          <p>Talks, books and websites about Functional Programming:</p>
+          <ul>
+          <li><a href="http://www.braveclojure.com">Clojure for the Brave and True</a></li>
+          <li><a href="http://learnyouahaskell.com">Learn You a Haskell for Great Good</a></li>
+          <li><a href="https://fsharpforfunandprofit.com">F# for fun and profit</a></li>
+          <li><a href="https://speakerdeck.com/pakoito/about-memory-management-in-fully-reactive-apps">Talk by Paco about Memory Management in Fully Reactive Apps</a></li>
+          </ul>
+          <p>Some of Paco's open source libraries:</p>
+          <ul>
+          <li><a href="https://github.com/pakoito/Komprehensions">Komprehensions</a></li>
+          <li><a href="https://github.com/pakoito/RxSealedUnions2">RxSealedUnions</a></li>
+          <li><a href="https://github.com/pakoito/RxTuples2">RxTuples</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Paco Estevez: <a href="https://twitter.com/pacoworks">Twitter</a>, <a href="https://github.com/pacoworks">GitHub</a>, <a href="https://www.pacoworks.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</title>
+      <description>In this episode we have talked to Alexey Tsvetkov from Jetbrains about Kotlin Gradle plugin, compilers and build systems.</description>
+      <pubDate>Tue, 11 Apr 2017 08:30:00 +0000</pubDate>
       <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part1.mp3</guid>
-      <title>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey
-                Tsvetkov</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_9_Part1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/57" rel="replies" type="text/html" />
-      <itunes:duration>45:42</itunes:duration>
-      <pubDate>Tue, 11 April 2017 08:30:00 EST</pubDate>
-      <enclosure length="65819851" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part1.mp3" />
-      <atom:contributor>
-        <atom:name>Alexey Tsvetkov</atom:name>
-        <atom:uri>https://twitter.com/tsvtkv</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 9, Part 1: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</h1>
-
-			<p><strong>Important note for Pocket Casts app users:</strong>
-			Unfortunately Pocket Casts android app has a problem with downloading our episodes (to listen to them offline).
-			It seems that while downloading their android app is using a old http client which doesn't support latest TLS cipher standards we use on server side to host our episodes.  </p>
-
-			<p>Nevertheless, <strong>streaming our episodes (instead of downloading) works</strong> in Pocket Casts android app.</p>
-
-			<p>See this tutorial: <a href="http://support.pocketcasts.com/article/streaming-episodes/">Pocket Casts: Streaming</a></p>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/62">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode we have talked with Alexey Tsvetkov who works at the Kotlin team at jetbrains on Kotlin's gradle plugin, compilers and build systems in general.</p>
-
-			<p>In the first part (of two parts) we have covered:</p>
-
-			<ul>
-			<li>Gradle Build System and its build phases</li>
-			<li>Kotlin Gradle plugin</li>
-			<li>Compiling mixed Kotlin and Java projects</li>
-			<li>Incremental compilation</li>
-			<li>How a compiler works</li>
-			<li>Compiler Frontends and Backends</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Alexey Tsvetkov <a href="https://twitter.com/tsvtkv">@tsvtkv</a>, <a href="https://github.com/tsvtkv">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://kotlinlang.org">Kotlin programming language</a></li>
-			<li><a href="https://docs.gradle.org/current/userguide/build_lifecycle.html">Gradle: The Build Lifecycle</a></li>
-			<li><a href="https://blog.jetbrains.com/kotlin/2017/04/kotlinnative-tech-preview-kotlin-without-a-vm/">Kotlin native</a></li>
-			<li><a href="https://github.com/JetBrains/intellij-community/tree/master/jps">JPS: IntelliJ IDEA's internal build system</a></li>
-			<li><a href="https://kotlinlang.org/docs/tutorials/koans.html">Kotlin Koans</a></li>
-			</ul>]]></itunes:summary>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part1.mp3" length="65819851" type="audio/mpeg"/>
+      <itunes:duration>00:45:42</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we have talked to Alexey Tsvetkov from Jetbrains about Kotlin Gradle plugin, compilers and build systems.</p>
+          <p><strong>Important note for Pocket Casts app users:</strong>
+          Unfortunately Pocket Casts android app has a problem with downloading our episodes (to listen to them offline).
+          It seems that while downloading their android app is using a old http client which doesn't support latest TLS cipher standards we use on server side to host our episodes.</p>
+          <p>Nevertheless, <strong>streaming our episodes (instead of downloading) works</strong> in Pocket Casts android app.</p>
+          <p>See this tutorial: <a href="http://support.pocketcasts.com/article/streaming-episodes/">Pocket Casts: Streaming</a></p>
+          <p>In this episode we have talked with Alexey Tsvetkov who works at the Kotlin team at jetbrains on Kotlin's gradle plugin, compilers and build systems in general.</p>
+          <p>In the first part (of two parts) we have covered:</p>
+          <ul>
+          <li>Gradle Build System and its build phases</li>
+          <li>Kotlin Gradle plugin</li>
+          <li>Compiling mixed Kotlin and Java projects</li>
+          <li>Incremental compilation</li>
+          <li>How a compiler works</li>
+          <li>Compiler Frontends and Backends</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://kotlinlang.org">Kotlin programming language</a></li>
+          <li><a href="https://docs.gradle.org/current/userguide/build_lifecycle.html">Gradle: The Build Lifecycle</a></li>
+          <li><a href="https://blog.jetbrains.com/kotlin/2017/04/kotlinnative-tech-preview-kotlin-without-a-vm/">Kotlin native</a></li>
+          <li><a href="https://github.com/JetBrains/intellij-community/tree/master/jps">JPS: IntelliJ IDEA's internal build system</a></li>
+          <li><a href="https://kotlinlang.org/docs/tutorials/koans.html">Kotlin Koans</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Alexey Tsvetkov: <a href="https://twitter.com/tsvtkv">Twitter</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/62">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 9, Part 2: Kotlin Gradle plugin, compilers and build systems with Alexey Tsvetkov</title>
+      <description>In the second part of episode 9 we have talked about build systems for android development: Gradle, Buck and Bazel</description>
+      <pubDate>Fri, 14 Apr 2017 08:30:00 +0000</pubDate>
       <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part2.mp3</guid>
-      <title>Episode 9, Part 2: Gradle, Buck and Bazel with Alexey Tsvetkov</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_9_Part2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/66" rel="replies" type="text/html" />
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part2.mp3" length="61642020" type="audio/mpeg"/>
       <itunes:duration>01:04:12</itunes:duration>
-      <pubDate>Fri, 14 April 2017 08:30:00 EST</pubDate>
-      <enclosure length="61642020" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.9.part2.mp3" />
-      <atom:contributor>
-        <atom:name>Alexey Tsvetkov</atom:name>
-        <atom:uri>https://twitter.com/tsvtkv</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 9, Part 2: Gradle, Buck and Bazel with Alexey Tsvetkov</h1>
-
-			<p><strong>Important note for Pocket Casts app users:</strong>
-			Thanks to the great support of Pocket Casts team we were able to fix the "download episodes issue" (see show nodes of episode 9, part 1).</p>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/66">Discussion after the episode</a></li>
-			</ul>
-
-			<p>We have continued our discussion with Alexey Tsvetkov. In the second part we have talked about build systems for android development.</p>
-
-			<p>We have talked about:</p>
-
-			<ul>
-			<li><a href="https://gradle.org">Gradle</a></li>
-			<li><a href="https://buckbuild.com">Buck</a></li>
-			<li><a href="https://bazel.build">Bazel</a></li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Alexey Tsvetkov <a href="https://twitter.com/tsvtkv">@tsvtkv</a>, <a href="https://github.com/tsvtkv">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://github.com/uber/okbuck">OkBuck</a></li>
-			<li><a href="http://fragmentedpodcast.com/episodes/68/">Fragmented Podcast, Episode 68: Talking Buck with Uber engineer Gautam Korlam</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In the second part of episode 9 we have talked about build systems for android development: Gradle, Buck and Bazel</p>
+          <p><strong>Important note for Pocket Casts app users:</strong>
+          Thanks to the great support of Pocket Casts team we were able to fix the &quot;download episodes issue&quot; (see show nodes of episode 9, part 1).</p>
+          <p>We have continued our discussion with Alexey Tsvetkov. In the second part we have talked about build systems for android development.</p>
+          <p>We have talked about:</p>
+          <ul>
+          <li><a href="https://gradle.org">Gradle</a></li>
+          <li><a href="https://buckbuild.com">Buck</a></li>
+          <li><a href="https://bazel.build">Bazel</a></li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/uber/okbuck">OkBuck</a></li>
+          <li><a href="http://fragmentedpodcast.com/episodes/68/">Fragmented Podcast, Episode 68: Talking Buck with Uber engineer Gautam Korlam</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Alexey Tsvetkov: <a href="https://twitter.com/tsvtkv">Twitter</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/62">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
+      <title>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from JetBrains</title>
+      <description>We&#39;ve talked to Dmitry Jemerov from Kotlin team at JetBrains about some language design decisions made in Kotlin</description>
+      <pubDate>Mon, 08 May 2017 15:30:00 +0000</pubDate>
       <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.10.mp3</guid>
-      <title>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from
-                JetBrains</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_10.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/68" rel="replies" type="text/html" />
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.10.mp3" length="108132883" type="audio/mpeg"/>
       <itunes:duration>01:15:04</itunes:duration>
-      <pubDate>Mon, 8 May 2017 15:30:00 EST</pubDate>
-      <enclosure length="108132883" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.10.mp3" />
-      <atom:contributor>
-        <atom:name>Dmitry Jemerov</atom:name>
-        <atom:uri>https://twitter.com/intelliyole</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 10: Kotlin Language Design Nitpicking with Dmitry Jemerov from JetBrains</h1>
-
-			<p>We know about sound volume level issue <a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/67">#67</a> and tried our best to maximize it in this episode, but Artem used his crappy headphones mic instead of professional one and we couldn't achieve what we wanted, sorry about that, we'll try our best in next episode.</p>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/68">Discussion after the episode</a></li>
-			</ul>
-
-			<p>We've talked to Dmitry Jemerov aka @yole from Kotlin team at JetBrains about some language design decisions made in Kotlin:</p>
-
-			<ul>
-			<li>Package visibility in Kotlin</li>
-			<li>Java static equivalent in Kotlin</li>
-			<li>Companion objects</li>
-			<li>Static extension functions</li>
-			<li>Classes are final by default but fields are public</li>
-			<li>Unchecked exceptions</li>
-			<li>Generics</li>
-			<li>Base types: Any, Unit, Nothing</li>
-			<li>Traits</li>
-			<li>Delegates</li>
-			<li>Data classes</li>
-			<li>Upcoming features</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<p>Dmitry Jemerov <a href="https://twitter.com/intelliyole">@intelliyole</a>, <a href="http://yole.ru/">personal blog</a>, <a href="https://github.com/yole/">GitHub</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://www.manning.com/books/kotlin-in-action">Book: Kotlin in Action written by Dmitry Jemerov and Svetlana Isakova</a></li>
-			<li><a href="http://kotlinlang.org/">Official Kotlin website with photo of lighthouse on Kotlin island</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>We've talked to Dmitry Jemerov from Kotlin team at JetBrains about some language design decisions made in Kotlin</p>
+          <p>We know about sound volume level issue <a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/67">#67</a> and tried our best to maximize it in this episode, but Artem used his crappy headphones mic instead of professional one and we couldn't achieve what we wanted, sorry about that, we'll try our best in next episode.</p>
+          <p>We've talked to Dmitry Jemerov aka @yole from Kotlin team at JetBrains about some language design decisions made in Kotlin:</p>
+          <ul>
+          <li>Package visibility in Kotlin</li>
+          <li>Java static equivalent in Kotlin</li>
+          <li>Companion objects</li>
+          <li>Static extension functions</li>
+          <li>Classes are final by default but fields are public</li>
+          <li>Unchecked exceptions</li>
+          <li>Generics</li>
+          <li>Base types: Any, Unit, Nothing</li>
+          <li>Traits</li>
+          <li>Delegates</li>
+          <li>Data classes</li>
+          <li>Upcoming features</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://www.manning.com/books/kotlin-in-action">Book: Kotlin in Action written by Dmitry Jemerov and Svetlana Isakova</a></li>
+          <li><a href="http://kotlinlang.org/">Official Kotlin website with photo of lighthouse on Kotlin island</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Dmitry Jemerov: <a href="https://twitter.com/intelliyole">Twitter</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/68">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3</guid>
       <title>Episode 11: Migration to RxJava 2 with Artur Dryomov from Juno</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_11.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/71" rel="replies" type="text/html" />
-      <itunes:duration>52:46</itunes:duration>
-      <pubDate>Mon, 15 May 2017 09:30:00 EST</pubDate>
-      <enclosure length="50658006" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3" />
-      <atom:contributor>
-        <atom:name>Artur Dryomov</atom:name>
-        <atom:uri>https://github.com/ming13</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 11: Migration to RxJava 2 with Artur Dryomov from Juno</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/71">Discussion after the episode</a></li>
-			</ul>
-
-			<p>We've talked to Artur about Juno's way to migrate their Android Riders App from RxJava 1 to RxJava 2. We have covered:</p>
-
-			<ul>
-			<li>Migration strategy at Juno</li>
-			<li>What's different in RxJava 2.0?</li>
-			<li>Null values in RxJava 2</li>
-			<li>Flowable or Observable?</li>
-			<li>Other Rx Types: Single, Maybe and Completable</li>
-			<li>RxJava 2 interop library</li>
-			<li>RxJava 2: Default UncaughtExceptionHandler logs exceptions silently in JVM unit tests</li>
-			<li>RxJava 3</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<ul>
-			<li>Artur Dryomov <a href="https://github.com/ming13">GitHub</a></li>
-			</ul>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://github.com/gojuno/engineering/blob/master/specs/rxjava-2-migration.md">Juno's Android Rider Team RxJava 2 Migration Specification</a></li>
-			<li><a href="https://github.com/ReactiveX/RxKotlin">RxKotlin</a></li>
-			<li><a href="https://github.com/akarnokd/RxJava2Interop">RxJava 2 interop library</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0">What's different in RxJava 2.0</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0#which-type-to-use">RxJava 2: Which type to use</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/issues/5234">RxJava 2: Uncaught errors fail silently in junit tests</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/issues/4644#issuecomment-256684743">RxJava 2: Discussion about null values</a></li>
-			<li><a href="https://github.com/reactive-streams/reactive-streams-jvm/issues/204">Reactive Streams specification: null value</a></li>
-			<li><a href="https://github.com/ReactiveX/RxKotlin/issues/103">RxJava 2 Kotlin SAM issue combineLatest()/etc</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/issues/4564">Why RxJava 3: Split the library into two or adding types for symmetry</a></li>
-			<li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
-			</ul>]]></itunes:summary>
+      <description>We&#39;ve talked to Artur about Juno&#39;s way to migrate their Android Riders App from RxJava 1 to RxJava 2.</description>
+      <pubDate>Mon, 15 May 2017 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.11.mp3" length="50658006" type="audio/mpeg"/>
+      <itunes:duration>00:52:46</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>We've talked to Artur about Juno's way to migrate their Android Riders App from RxJava 1 to RxJava 2.</p>
+          <p>We have covered:</p>
+          <ul>
+          <li>Migration strategy at Juno</li>
+          <li>What's different in RxJava 2.0?</li>
+          <li>Null values in RxJava 2</li>
+          <li>Flowable or Observable?</li>
+          <li>Other Rx Types: Single, Maybe and Completable</li>
+          <li>RxJava 2 interop library</li>
+          <li>RxJava 2: Default UncaughtExceptionHandler logs exceptions silently in jvm unit tests</li>
+          <li>RxJava 3</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/gojuno/engineering/blob/master/specs/rxjava-2-migration.md">Juno's Android Rider Team RxJava 2 Migration Specification</a></li>
+          <li><a href="https://github.com/ReactiveX/RxKotlin">RxKotlin</a></li>
+          <li><a href="https://github.com/akarnokd/RxJava2Interop">RxJava 2 interop library</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0">What's different in RxJava 2.0</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/wiki/What%27s-different-in-2.0#which-type-to-use">RxJava 2: Which type to use</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/issues/5234">RxJava 2: Uncaught errors fail silently in junit tests</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/issues/4644#issuecomment-256684743">RxJava 2: Discussion about null values</a></li>
+          <li><a href="https://github.com/ReactiveX/RxKotlin/issues/103">RxJava 2 Kotlin SAM issue combineLatest()/etc</a></li>
+          <li><a href="https://github.com/reactive-streams/reactive-streams-jvm/issues/204">Reactive Streams specification: null value</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/issues/4564">Why RxJava 3: Split the library into two or adding types for symmetry</a></li>
+          <li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/71">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3</guid>
       <title>Episode 12: Instant Apps with Lukas Olsen and Christian Bahl</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_12.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/74" rel="replies" type="text/html" />
-      <itunes:duration>31:47</itunes:duration>
-      <pubDate>Mon, 24 May 2017 09:30:00 EST</pubDate>
-      <enclosure length="30566084" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3" />
-      <atom:contributor>
-        <atom:name>Christian Bahl</atom:name>
-        <atom:uri>https://twitter.com/christian_bahl</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 12: Instant Apps with Lukas Olsen and Christian Bahl</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/74">Discussion after the episode</a></li>
-			</ul>
-                        <p>We apologize for the bad sound quality and low sound volume.</p>
-
-			<p>Hannes chatted with his coworkes Lukas and Christian about Instant Apps. Unfortunately, Artem wasn't able to join us for this episode. We have covered:</p>
-
-			<ul>
-			<li>How Instant Apps work</li>
-			<li>Limitations</li>
-			<li>Accelerated Mobile Pages (AMP)</li>
-			<li>Gradle Plugins: com.android.instantapp and com.android.feature</li>
-			<li>Sharing code between regular App and Instant App</li>
-			<li>User Experience with Instant Apps</li>
-			<li>Instant App Early Access Preview Program</li>
-			<li>Our personal Google I/O 2017 highlights:
-			<ul><li><a href="https://youtu.be/fPzxfeDJDzY">Life is Great and Everything Will Be Ok, Kotlin is Here</a></li>
-			<li><a href="https://youtu.be/FrteWKKVyzI?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Architecture Components</a></li>
-			<li><a href="https://youtu.be/7ll-rkLCtyk?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Speeding Up Your Android Gradle Builds</a></li>
-			<li><a href="https://youtu.be/oispNrpGnIY?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Introduction to Android Instant Apps</a></li></ul></li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<ul>
-			<li>Lukas Olsen </li>
-			<li>Christian Bahl <a href="https://twitter.com/christian_bahl">@christian_bahl</a>, <a href="https://github.com/Bodo1981">GitHub</a></li>
-			</ul>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://developer.android.com/topic/instant-apps/index.html">Instant Apps Documentation</a></li>
-			<li><a href="https://www.ampproject.org">Accelerated Mobile Pages (AMP)</a></li>
-			<li><a href="https://www.youtube.com/playlist?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Google I/O 2017 Video Playlist</a></li>
-			</ul>]]></itunes:summary>
+      <description>Hannes chatted with his coworkes Lukas and Christian about Instant Apps.</description>
+      <pubDate>Wed, 24 May 2017 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.12.mp3" length="30566084" type="audio/mpeg"/>
+      <itunes:duration>00:31:47</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>Hannes chatted with his coworkes Lukas and Christian about Instant Apps.</p>
+          <p>We apologize for the bad sound quality and low sound volume.</p>
+          <p>Hannes chatted with his coworkes Lukas and Christian about Instant Apps. Unfortunately, Artem wasn't able to join us for this episode. We have covered:</p>
+          <ul>
+          <li>How Instant Apps work</li>
+          <li>Limitations</li>
+          <li>Accelerated Mobile Pages (AMP)</li>
+          <li>Gradle Plugins: com.android.instantapp and com.android.feature</li>
+          <li>Sharing code between regular App and Instant App</li>
+          <li>User Experience with Instant Apps</li>
+          <li>Instant App Early Access Preview Program</li>
+          <li>Our personal Google I/O 2017 highlights:
+          <ul>
+          <li><a href="https://youtu.be/fPzxfeDJDzY">Life is Great and Everything Will Be Ok, Kotlin is Here</a></li>
+          <li><a href="https://youtu.be/FrteWKKVyzI?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Architecture Components</a></li>
+          <li><a href="https://youtu.be/7ll-rkLCtyk?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Speeding Up Your Android Gradle Builds</a></li>
+          <li><a href="https://youtu.be/oispNrpGnIY?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Introduction to Android Instant Apps</a></li>
+          </ul>
+          </li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://developer.android.com/topic/instant-apps/index.html">Instant Apps Documentation</a></li>
+          <li><a href="https://www.ampproject.org">Accelerated Mobile Pages (AMP)</a></li>
+          <li><a href="https://www.youtube.com/playlist?list=PLOU2XLYxmsIKC8eODk_RNCWv3fBcLvMMy">Google I/O 2017 Video Playlist</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Christian Bahl: <a href="https://twitter.com/christian_bahl">Twitter</a></li>
+          <li>Lukas Olsen</li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/71">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3</guid>
       <title>Episode 13: Conductor with Eric Kuck</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_13.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/76" rel="replies" type="text/html" />
+      <description>In this episode we talked about Conductor with creator Eric Kuck.</description>
+      <pubDate>Fri, 04 Aug 2017 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3" length="61832318" type="audio/mpeg"/>
       <itunes:duration>01:04:23</itunes:duration>
-      <pubDate>Fri, 4 August 2017 09:30:00 EST</pubDate>
-      <enclosure length="61832318" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.13.mp3" />
-      <atom:contributor>
-        <atom:name>Eric Kuck</atom:name>
-        <atom:uri>https://twitter.com/eric_kuck</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 13: Conductor with Eric Kuck</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/76">Discussion after the episode</a></li>
-			</ul>
-
-			<p><strong>Announcement:</strong> We have a new Co-Host for our podcast: Welcome <a href="https://twitter.com/arturdryomov">Artur Dryomov</a>!</p>
-
-			<p>We think that we need at least two hosts on each episode to produce a high-quality content.
-			Unfortunately, podcast production is time-consuming but now there are three hosts, so we can ensure that at least two of us have time to produce a new episode regularly.</p>
-
-			<p>In this episode Artur and Hannes chatted with Eric Kuck about <a href="https://github.com/bluelinelabs/Conductor">Conductor</a>, a framework created by Eric as alternative to Fragments. We discussed:</p>
-
-			<ul>
-			<li>Motivation behind Conductor</li>
-			<li>Conductor components: Controller, Router, ChangeHandler and ControllerTransaction</li>
-			<li>How Conductor works behind the scenes</li>
-			<li>Single Activity Applications</li>
-			<li>Testing</li>
-			<li>The future of Conductor</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<ul>
-			<li>Eric Kuck <a href="https://twitter.com/eric_kuck">@eric_kuck</a>, <a href="https://github.com/EricKuck">GitHub</a></li>
-			</ul>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="https://github.com/ming13">GitHub</a></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://github.com/bluelinelabs/Conductor">Conductor on GitHub</a></li>
-			<li><a href="https://github.com/EricKuck/ConductorGlideDemo">Demo of Glide integration with Controller LifecycleListener</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we talked about Conductor with creator Eric Kuck.</p>
+          <p><strong>Announcement:</strong> We have a new Co-Host for our podcast: Welcome <a href="https://twitter.com/arturdryomov">Artur Dryomov</a>!</p>
+          <p>We think that we need at least two hosts on each episode to produce a high-quality content.
+          Unfortunately, podcast production is time-consuming but now there are three hosts, so we can ensure that at least two of us have time to produce a new episode regularly.</p>
+          <p>In this episode Artur and Hannes chatted with Eric Kuck about <a href="https://github.com/bluelinelabs/Conductor">Conductor</a>, a framework created by Eric as alternative to Fragments. We discussed:</p>
+          <ul>
+          <li>Motivation behind Conductor</li>
+          <li>Conductor components: Controller, Router, ChangeHandler and ControllerTransaction</li>
+          <li>How Conductor works behind the scenes</li>
+          <li>Single Activity Applications</li>
+          <li>Testing</li>
+          <li>The future of Conductor</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/bluelinelabs/Conductor">Conductor on GitHub</a></li>
+          <li><a href="https://github.com/EricKuck/ConductorGlideDemo">Demo of Glide integration with Controller LifecycleListener</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Eric Kuck: <a href="https://twitter.com/eric_kuck">Twitter</a>, <a href="https://github.com/EricKuck">GitHub</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/76">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.14.mp3</guid>
       <title>Episode 14: RxJava — the Present and Future with David Karnok (core maintainer)</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_14.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/80" rel="replies" type="text/html" />
+      <description>In this episode we chatted with core maintainer David Karnok about the present and the future of RxJava.</description>
+      <pubDate>Thu, 05 Oct 2017 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.14.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.14.mp3" length="77973101" type="audio/mpeg"/>
       <itunes:duration>01:21:11</itunes:duration>
-      <pubDate>Thu, 5 October 2017 09:30:00 EST</pubDate>
-      <enclosure length="77973101" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.14.mp3" />
-      <atom:contributor>
-        <atom:name>David Karnok</atom:name>
-        <atom:uri>https://twitter.com/akarnokd</atom:uri>
-      </atom:contributor>
-      <itunes:summary><![CDATA[<h1>Episode 14: RxJava — the Present and Future with David Karnok (core maintainer)</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/80">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode Artem and Hannes chatted with David Karnok about present and future of <a href="https://github.com/ReactiveX/RxJava">RxJava's</a>. We discussed:</p>
-
-			<ul>
-			<li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
-			<li>Kaushik Gopal's blog post:<a href="https://blog.kaush.co/2017/06/21/rxjava1-rxjava2-migration-understanding-changes/">RxJava 1 -> RxJava 2 (Understanding the Changes)</a></li>
-			<li>Artem Zinnatullin's <a href="https://artemzin.com/blog/reply-to-kaushik-gopals-aricle-rxjava-1-rxjava-2-understanding-the-changes/">Reply to Kaushik Gopal's aricle: "RxJava 1 -> RxJava 2 (Understanding the Changes)"</a></li>
-			<li><a href="https://kotlinlang.org/docs/reference/coroutines.html">Kotlin Coroutines</a></li>
-			<li><a href="https://github.com/JakeWharton/Reagent/">Reagent</a>: Experiments for future reactive libraries by using Kotlin Coroutines by JakeWharton</li>
-			<li><a href="http://akarnokd.blogspot.de/2017/09/rxjava-vs-kotlin-coroutines-quick-look.html">RxJava vs. Kotlin Coroutines, a quick look</a> by David Karnok
-			<ul><li><a href="http://akarnokd.blogspot.de/2017/09/rewriting-rxjava-with-kotlin-coroutines.html">Rewriting RxJava with Kotlin Coroutines?</a> by David Karnok</li></ul></li>
-			<li><a href="http://akarnokd.blogspot.de/2017/09/interoperation-between-rxjava-and.html">Interoperation between RxJava and Kotlin Coroutines</a> by David Karnok</li>
-			</ul>
-
-			<h4>Guest:</h4>
-
-			<ul>
-			<li><p>David Karnok <a href="https://twitter.com/akarnokd">@akarnokd</a>, <a href="https://github.com/akarnokd">GitHub</a>, <a href="http://akarnokd.blogspot.de">Blog</a></p>
-
-			<h4>Hosts:</h4>
-
-			<ul><li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li></ul></li>
-			</ul>
-
-			<h4>Additional links:</h4>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_1.md">Episode 3 of The Context Podcast featuren David Karnok</a></li>
-			<li><a href="https://github.com/ReactiveX/RxJava/wiki/Backpressure">RxJava Documentation: Backpressure</a></li>
-			<li><a href="https://community.oracle.com/docs/DOC-1006738">Reactive Programming with JDK 9 Flow API</a></li>
-			<li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode we chatted with core maintainer David Karnok about the present and the future of RxJava.</p>
+          <p>In this episode Artem and Hannes chatted with David Karnok about present and future of <a href="https://github.com/ReactiveX/RxJava">RxJava</a>. We discussed:</p>
+          <ul>
+          <li><a href="https://github.com/akarnokd/RxJava3-preview">RxJava 3 Preview</a></li>
+          <li>Kaushik Gopal's blog post: <a href="https://blog.kaush.co/2017/06/21/rxjava1-rxjava2-migration-understanding-changes/">RxJava 1 -&gt; RxJava 2 (Understanding the Changes)</a></li>
+          <li>Artem Zinnatullin's <a href="https://artemzin.com/blog/reply-to-kaushik-gopals-aricle-rxjava-1-rxjava-2-understanding-the-changes/">Reply to Kaushik Gopal's aricle: &quot;RxJava 1 -&gt; RxJava 2 (Understanding the Changes)&quot;</a></li>
+          <li><a href="https://kotlinlang.org/docs/reference/coroutines.html">Kotlin Coroutines</a></li>
+          <li><a href="https://github.com/JakeWharton/Reagent/">Reagent</a>: Experiments for future reactive libraries by using Kotlin Coroutines by Jake Wharton</li>
+          <li><a href="http://akarnokd.blogspot.de/2017/09/rxjava-vs-kotlin-coroutines-quick-look.html">RxJava vs. Kotlin Coroutines, a quick look</a> by David Karnok</li>
+          <li><a href="http://akarnokd.blogspot.de/2017/09/rewriting-rxjava-with-kotlin-coroutines.html">Rewriting RxJava with Kotlin Coroutines?</a> by David Karnok</li>
+          <li><a href="http://akarnokd.blogspot.de/2017/09/interoperation-between-rxjava-and.html">Interoperation between RxJava and Kotlin Coroutines</a> by David Karnok</li>
+          </ul>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_3_Part_1.md">Episode 3 of The Context Podcast featuring David Karnok</a></li>
+          <li><a href="https://github.com/ReactiveX/RxJava/wiki/Backpressure">RxJava Documentation: Backpressure</a></li>
+          <li><a href="https://community.oracle.com/docs/DOC-1006738">Reactive Programming with JDK 9 Flow API</a></li>
+          <li><a href="http://slack.kotlinlang.org">Kotlin Slack</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>David Karnok: <a href="https://twitter.com/akarnokd">Twitter</a>, <a href="https://github.com/akarnokd">GitHub</a>, <a href="http://akarnokd.blogspot.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/76">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.15.mp3</guid>
       <title>Episode 15: 2017 in Retrospective</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_15.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/83" rel="replies" type="text/html" />
+      <description>In this episode Artur and Hannes do a retrospective on 2017. They share their personal highlights, favorite talks, disapointments, learnings and much more.</description>
+      <pubDate>Sat, 20 Jan 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.15.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.15.mp3" length="63868600" type="audio/mpeg"/>
       <itunes:duration>01:15:56</itunes:duration>
-      <pubDate>Sat, 20 January 2018 09:30:00 EST</pubDate>
-      <enclosure length="63868600" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.15.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 15: 2017 in Retrospective</h1>
-
-			<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-			<ul>
-			<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/83">Discussion after the episode</a></li>
-			</ul>
-
-			<p>In this episode Artur and Hannes do a retrospective on 2017. They share their personal highlights, favorite talks, disapointments, learnings and much more.</p>
-
-			<h4>Hosts:</h4>
-
-			<ul>
-			<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="http://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-			<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-			</ul>
-
-			<h4>Links:</h4>
-
-			<p>Talks:</p>
-
-			<ul>
-			<li><a href="https://www.youtube.com/watch?v=YxOTU9F_YX4">Two Stones, One Bird: Implementation Tradeoffs by Christina Lee - KotlinConf 2017</a></li>
-			<li><a href="https://www.youtube.com/watch?v=R425cc6XrvA">Testing Kotlin at Scale: Spek by Artem Zinnatullin - KotlinConf 2017</a></li>
-			<li><a href="https://www.youtube.com/watch?v=KjoMnsc2lPo">The Reactive Workflow Pattern</a> (Droidcon New York 2017) and <a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">Update</a> (Droidcon San Francisco) by Ray Ryan </li>
-			<li><a href="https://github.com/JetBrains/kotlinconf-app">The Resurgence of SQL by Jake Wharton and Alec Strong - Droidcon New York City 2017</a></li>
-			<li><a href="https://www.youtube.com/watch?v=ksgmm8VolT4&amp;t=840s">Embracing SQL Without Abstraction by Alec Strong - Droidcon New York City 2016</a></li>
-			<li><a href="http://uk.droidcon.com/skillscasts/10784-openyolo-authentication-made-easy-and-secure">OpenYOLO: Authentication made easy and secure by Iain McGinniss - Droidcon London 2017</a> and corresponding <a href="https://blog.agilebits.com/2017/10/26/integrate-1password-into-your-android-apps/">blog post</a> </li>
-			</ul>
-
-			<p>Libraries:</p>
-
-			<ul>
-			<li><a href="http://spekframework.org/">Spek</a></li>
-			<li><a href="https://developer.android.com/topic/libraries/architecture/room.html">Room</a></li>
-			<li><a href="https://github.com/airbnb/lottie-android">Lottie</a></li>
-			<li><a href="https://github.com/JakeWharton/Reagent">Reagent: Experiments for future reactive libraries (by using coroutines)</a></li>
-			</ul>
-
-			<p>Programming Languages and Technologies:</p>
-
-			<ul>
-			<li><a href="https://www.typescriptlang.org/">TypeScript</a></li>
-			<li><a href="https://www.dartlang.org/">Dart</a></li>
-			<li><a href="https://en.wikipedia.org/wiki/WebOS">WebOS</a></li>
-			</ul>
-
-			<p>Other Links:</p>
-
-			<ul>
-			<li>Book recommendation: <a href="https://www.goodreads.com/book/show/28257707-the-subtle-art-of-not-giving-a-f-ck">The Subtle Art of Not Giving a F*ck: A Counterintuitive Approach to Living a Good Life</a></li>
-			<li>Christina Lee's tweet: <a href="https://twitter.com/RunChristinaRun/status/917187298546008065">"Does it matter to you if speakers have given their talk before?"</a></li>
-			<li><a href="https://github.com/JetBrains/kotlinconf-app">KotlinConf 2017 App</a></li>
-			<li><a href="http://flavienlaurent.com/blog/2014/01/31/spans">Spans, a Powerful Concept by Flavien Laurent</a></li>
-			<li><a href="https://developer.android.com/reference/android/support/v4/app/ActivityCompat.html#shouldShowRequestPermissionRationale">shouldShowRequestPermissionRationale()</a></li>
-			<li><a href="https://developer.android.com/reference/android/os/SharedMemory.html">SharedMemory</a></li>
-			<li>People to follow: <a href="https://twitter.com/clattner_llvm">Chris Lattner</a></li>
-			</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode Artur and Hannes do a retrospective on 2017. They share their personal highlights, favorite talks, disapointments, learnings and much more.</p>
+          <p><strong>Links</strong></p>
+          <p>Talks</p>
+          <ul>
+          <li><a href="https://www.youtube.com/watch?v=YxOTU9F_YX4">Two Stones, One Bird: Implementation Tradeoffs by Christina Lee - KotlinConf 2017</a></li>
+          <li><a href="https://www.youtube.com/watch?v=R425cc6XrvA">Testing Kotlin at Scale: Spek by Artem Zinnatullin - KotlinConf 2017</a></li>
+          <li><a href="https://www.youtube.com/watch?v=KjoMnsc2lPo">The Reactive Workflow Pattern</a> (Droidcon New York 2017) and <a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">Update</a> (Droidcon San Francisco) by Ray Ryan</li>
+          <li><a href="https://github.com/JetBrains/kotlinconf-app">The Resurgence of SQL by Jake Wharton and Alec Strong - Droidcon New York City 2017</a></li>
+          <li><a href="https://www.youtube.com/watch?v=ksgmm8VolT4&amp;t=840s">Embracing SQL Without Abstraction by Alec Strong - Droidcon New York City 2016</a></li>
+          <li><a href="http://uk.droidcon.com/skillscasts/10784-openyolo-authentication-made-easy-and-secure">OpenYOLO: Authentication made easy and secure by Iain McGinniss - Droidcon London 2017</a> and corresponding <a href="https://blog.agilebits.com/2017/10/26/integrate-1password-into-your-android-apps/">blog post</a></li>
+          </ul>
+          <p>Libraries</p>
+          <ul>
+          <li><a href="http://spekframework.org/">Spek</a></li>
+          <li><a href="https://developer.android.com/topic/libraries/architecture/room.html">Room</a></li>
+          <li><a href="https://github.com/airbnb/lottie-android">Lottie</a></li>
+          <li><a href="https://github.com/JakeWharton/Reagent">Reagent:</a> Experiments for future reactive libraries (by using coroutines).</li>
+          </ul>
+          <p>Programming Languages and Technologies</p>
+          <ul>
+          <li><a href="https://www.typescriptlang.org/">TypeScript</a></li>
+          <li><a href="https://www.dartlang.org/">Dart</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/WebOS">WebOS</a></li>
+          </ul>
+          <p>Other Links</p>
+          <ul>
+          <li>Book recommendation: <a href="https://www.goodreads.com/book/show/28257707-the-subtle-art-of-not-giving-a-f-ck">The Subtle Art of Not Giving a F*ck: A Counterintuitive Approach to Living a Good Life</a></li>
+          <li>Christina Lee's tweet: <a href="https://twitter.com/RunChristinaRun/status/917187298546008065">&quot;Does it matter to you if speakers have given their talk before?&quot;</a></li>
+          <li><a href="https://github.com/JetBrains/kotlinconf-app">KotlinConf 2017 App</a></li>
+          <li><a href="http://flavienlaurent.com/blog/2014/01/31/spans">Spans, a Powerful Concept by Flavien Laurent</a></li>
+          <li><a href="https://developer.android.com/reference/android/support/v4/app/ActivityCompat.html#shouldShowRequestPermissionRationale">shouldShowRequestPermissionRationale()</a></li>
+          <li><a href="https://developer.android.com/reference/android/os/SharedMemory.html">SharedMemory</a></li>
+          <li>People to follow: <a href="https://twitter.com/clattner_llvm">Chris Lattner</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/83">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.16.mp3</guid>
       <title>Episode 16: Tools</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_16.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/86" rel="replies" type="text/html" />
+      <description>In this episode Artem, Artur and Hannes discuss the tools they use for development.</description>
+      <pubDate>Wed, 07 Mar 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.16.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.16.mp3" length="53020028" type="audio/mpeg"/>
       <itunes:duration>01:02:48</itunes:duration>
-      <pubDate>Wed, 7 March 2018 09:30:00 EST</pubDate>
-      <enclosure length="53020028" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.16.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 16: Tools</h1>
-
-                    <h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-                    <ul>
-                    <li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/86">Discussion after the episode</a></li>
-                    </ul>
-
-                    <p>In this episode Artem, Artur and Hannes discuss the tools they use for development.</p>
-
-                    <h4>Hosts:</h4>
-
-                    <ul>
-                    <li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-                    <li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-                    <li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="http://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-                    </ul>
-
-                    <h4>Links:</h4>
-
-                    <p>Tools:</p>
-
-                    <ul>
-                    <li><a href="https://github.com/gojuno/mainframer">Mainframer</a></li>
-                    <li><a href="https://github.com/gojuno/composer">Composer</a></li>
-                    <li><a href="https://github.com/gojuno/swarmer">Swarmer</a></li>
-                    <li><a href="http://ohmyz.sh">zsh</a></li>
-                    <li><a href="https://github.com/AlDanial/cloc">cloc</a></li>
-                    <li><a href="https://en.wikipedia.org/wiki/Ncdu">ncdu</a></li>
-                    <li><a href="https://jonas.github.io/tig/">tig</a></li>
-                    <li><a href="https://geoff.greer.fm/ag/">ag</a></li>
-                    </ul>
-
-                    <p>CI:</p>
-
-                    <ul>
-                    <li><a href="https://jenkins.io">Jenkins</a></li>
-                    <li><a href="http://circleci.com">CircleCi</a></li>
-                    <li><a href="https://drone.io">Drone</a></li>
-                    </ul>
-
-                    <p>Libraries:</p>
-
-                    <ul>
-                    <li><a href="http://spekframework.org/">Spek</a></li>
-                    <li><a href="https://github.com/JakeWharton/RxReplayingShare">RxReplayingShare</a></li>
-                    <li><a href="https://github.com/square/moshi">Moshi</a></li>
-                    </ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode Artem, Artur and Hannes discuss the tools they use for development.</p>
+          <p>Tools:</p>
+          <ul>
+          <li><a href="https://github.com/gojuno/mainframer">Mainframer</a></li>
+          <li><a href="https://github.com/gojuno/composer">Composer</a></li>
+          <li><a href="https://github.com/gojuno/swarmer">Swarmer</a></li>
+          <li><a href="http://ohmyz.sh">zsh</a></li>
+          <li><a href="https://github.com/AlDanial/cloc">cloc</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Ncdu">ncdu</a></li>
+          <li><a href="https://jonas.github.io/tig/">tig</a></li>
+          <li><a href="https://geoff.greer.fm/ag/">ag</a></li>
+          </ul>
+          <p>CI:</p>
+          <ul>
+          <li><a href="https://jenkins.io">Jenkins</a></li>
+          <li><a href="http://circleci.com">CircleCi</a></li>
+          <li><a href="https://drone.io">Drone</a></li>
+          </ul>
+          <p>Libraries:</p>
+          <ul>
+          <li><a href="http://spekframework.org/">Spek</a></li>
+          <li><a href="https://github.com/JakeWharton/RxReplayingShare">RxReplayingShare</a></li>
+          <li><a href="https://github.com/square/moshi">Moshi</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/86">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.17.mp3</guid>
       <title>Episode 17: Switching Gears to C# and .NET</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_17.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/90" rel="replies" type="text/html" />
-      <itunes:duration>57:37</itunes:duration>
-      <pubDate>Sun, 1 April 2018 09:30:00 EST</pubDate>
-      <enclosure length="48665265" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.17.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 17: Switching Gears to C# and .NET</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/90">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In this episode Artur chatted with Dmitry Savchenko about C#, .NET and everything in between.</p>
-
-				<p>The reason is simple — we are changing our jobs as Android developers to be real enterprise professionals.
-				Prepare for next episodes about macOS AppKit, Linux kernel, Go microservices and Plan 9 vs. Inferno.
-				And maybe gardening at some point. Also — April Fools!</p>
-
-				<p>Seriously though — the episode is a great introduction into C# world. Just for erudition sake, you know.</p>
-
-				<h4>Guest:</h4>
-
-				<ul>
-				<li>Dmitry Savchenko: <a href="https://github.com/dsav">GitHub</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="http://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-				</ul>
-
-				<h4>Links:</h4>
-
-				<p>C#</p>
-
-				<ul>
-				<li><a href="https://en.wikipedia.org/wiki/Anders_Hejlsberg">Anders Hejlsberg — Turbo Pascal, C# and TypeScript designer</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history">Versions history</a></li>
-				<li><a href="https://github.com/dotnet/csharplang/wiki/Nullable-Reference-Types-Preview">Nullable reference types preview</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/struct"><code>struct</code></a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/async"><code>async</code> and <code>await</code></a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/yield"><code>yield</code></a></li>
-				<li><a href="http://fsharp.org/">F#</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/quantum/quantum-qr-intro">Q#</a></li>
-				</ul>
-
-				<p>.NET</p>
-
-				<ul>
-				<li><a href="https://en.wikipedia.org/wiki/.NET_Framework">.NET Framework</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/core/">.NET Core</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/dotnet/standard/choosing-core-framework-server">.NET Framework vs. .NET Core</a></li>
-				</ul>
-
-				<p>Tools</p>
-
-				<ul>
-				<li><a href="https://www.jetbrains.com/resharper/">JetBrains ReSharper</a></li>
-				<li><a href="https://www.jetbrains.com/rider/">JetBrains Rider</a></li>
-				<li><a href="https://github.com/dotnet/roslyn">Roslyn — .NET Compiler Platform</a></li>
-				<li><a href="https://code.visualstudio.com/">Visual Studio Code</a></li>
-				<li><a href="https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild">MSBuild</a></li>
-				<li><a href="https://www.nuget.org/">NuGet</a></li>
-				<li><a href="https://www.visualstudio.com/tfs/">Team Foundation Server</a></li>
-				</ul>]]></itunes:summary>
+      <description>Artur chatted with Dmitry Savchenko about C#, .NET and everything in between.</description>
+      <pubDate>Sun, 01 Apr 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.17.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.17.mp3" length="48665265" type="audio/mpeg"/>
+      <itunes:duration>00:57:37</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>Artur chatted with Dmitry Savchenko about C#, .NET and everything in between.</p>
+          <p>The reason is simple — we are changing our jobs as Android developers to be real enterprise professionals.
+          Prepare for next episodes about macOS AppKit, Linux kernel, Go microservices and Plan 9 vs. Inferno.
+          And maybe gardening at some point. Also — April Fools!</p>
+          <p>Seriously though — the episode is a great introduction into C# world. Just for erudition sake, you know.</p>
+          <p>Links:</p>
+          <p>C#</p>
+          <ul>
+          <li><a href="https://en.wikipedia.org/wiki/Anders_Hejlsberg">Anders Hejlsberg — Turbo Pascal, C# and TypeScript designer</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-version-history">Versions history</a></li>
+          <li><a href="https://github.com/dotnet/csharplang/wiki/Nullable-Reference-Types-Preview">Nullable reference types preview</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/struct"><code>struct</code></a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/async"><code>async</code> and <code>await</code></a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/yield"><code>yield</code></a></li>
+          <li><a href="http://fsharp.org/">F#</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/quantum/quantum-qr-intro">Q#</a></li>
+          </ul>
+          <p>.NET</p>
+          <ul>
+          <li><a href="https://en.wikipedia.org/wiki/.NET_Framework">.NET Framework</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/core/">.NET Core</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/dotnet/standard/choosing-core-framework-server">.NET Framework vs. .NET Core</a></li>
+          </ul>
+          <p>Tools</p>
+          <ul>
+          <li><a href="https://www.jetbrains.com/resharper/">JetBrains ReSharper</a></li>
+          <li><a href="https://www.jetbrains.com/rider/">JetBrains Rider</a></li>
+          <li><a href="https://github.com/dotnet/roslyn">Roslyn — .NET Compiler Platform</a></li>
+          <li><a href="https://code.visualstudio.com/">Visual Studio Code</a></li>
+          <li><a href="https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild">MSBuild</a></li>
+          <li><a href="https://www.nuget.org/">NuGet</a></li>
+          <li><a href="https://www.visualstudio.com/tfs/">Team Foundation Server</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Dmitry Savchenko: <a href="https://github.com/dsav">GitHub</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/90">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part1.mp3</guid>
       <title>Episode 18, Part 1: Android Everywhere</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_18_Part1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92" rel="replies" type="text/html" />
-      <itunes:duration>53:49</itunes:duration>
-      <pubDate>Sat, 5 May 2018 09:30:00 EST</pubDate>
-      <enclosure length="45465440" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part1.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 18, Part 1: Android Everywhere</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In the first part of episode #18 Artur, Hannes und Artem discuss Android tablets, Chromebooks and Android Wear (Wear OS).</p>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="https://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="https://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-				</ul>
-
-				<h4>Links:</h4>
-
-				<ul>
-				<li><a href="https://www.youtube.com/watch?v=Ym1KkXPa9aA">Fireside Chat with Matias Duarte, VP of Design, Android</a>: Interesting interview with Matias Duarte about form factors like mobile, wearables, TV, Chromebooks and watch.</li>
-				</ul>]]></itunes:summary>
+      <description>In the first part of episode #18 Artur, Hannes und Artem discuss Android tablets, Chromebooks and Android Wear (Wear OS).</description>
+      <pubDate>Sat, 05 May 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part1.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part1.mp3" length="45465440" type="audio/mpeg"/>
+      <itunes:duration>00:53:49</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>In the first part of episode #18 Artur, Hannes und Artem discuss Android tablets, Chromebooks and Android Wear (Wear OS).</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://www.youtube.com/watch?v=Ym1KkXPa9aA">Fireside Chat with Matias Duarte, VP of Design, Android</a>: Interesting interview with Matias Duarte about form factors like mobile, wearables, TV, Chromebooks and watch.</li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part2.mp3</guid>
       <title>Episode 18, Part 2: Android Everywhere</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_18_Part2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92" rel="replies" type="text/html" />
+      <description>In the second part of episode #18 Artur, Hannes and Artem discuss Android TV, Chromecast and Android Auto.</description>
+      <pubDate>Mon, 07 May 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part2.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part2.mp3" length="52152856" type="audio/mpeg"/>
       <itunes:duration>01:01:46</itunes:duration>
-      <pubDate>Mon, 7 May 2018 09:30:00 EST</pubDate>
-      <enclosure length="52152856" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.18.part2.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 18, Part 2: Android Everywhere</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In the second part of episode #18 Artur, Hannes and Artem discuss Android TV, Chromecast and Android Auto.</p>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="https://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="https://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-				</ul>
-
-				<h4>Links:</h4>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_5.md">The Context Episode 5: Android TV with Joe Birch</a></li>
-				<li><a href="https://medium.com/exploring-android/android-tv-chill-3ba9c413daef">Android TV &amp; Chill</a>: A concept for what it would be like ordering fast-food on Android TV by Joe Birch.</li>
-				<li><a href="https://www.reddit.com/r/Android/comments/7zf4tk/openauto_turns_a_raspberry_pi_into_an_android/">OpenAuto</a>: Turns a raspberry pi into an Android Auto device.</li>
-				<li><a href="https://www.amazon.com/dp/B074Y71ZKC">Artem's car system running Android</a></li>
-				</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In the second part of episode #18 Artur, Hannes and Artem discuss Android TV, Chromecast and Android Auto.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_5.md">The Context Episode 5: Android TV with Joe Birch</a></li>
+          <li><a href="https://medium.com/exploring-android/android-tv-chill-3ba9c413daef">Android TV &amp; Chill</a>: A concept for what it would be like ordering fast-food on Android TV by Joe Birch.</li>
+          <li><a href="https://www.reddit.com/r/Android/comments/7zf4tk/openauto_turns_a_raspberry_pi_into_an_android/">OpenAuto</a>: Turns a Raspberry Pi into an Android Auto device.</li>
+          <li><a href="https://www.amazon.com/dp/B074Y71ZKC">Artem's car system running Android</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/92">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part1.mp3</guid>
       <title>Episode 19, Part 1: Model-View-Intent with Benoît Quenaudon from Square</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_19_Part1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95" rel="replies" type="text/html" />
-      <itunes:duration>37:06</itunes:duration>
-      <pubDate>Sun, 10 June 2018 09:30:00 EST</pubDate>
-      <enclosure length="31423481 " type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part1.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 19, Part 1: Model-View-Intent with Benoît Quenaudon from Square</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In the first part of episode #19 Artur and Hannes chatted with Benoît Quenaudon from Square about Model-View-Intent.
-				We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</p>
-
-				<h3>Guest:</h3>
-
-				<ul>
-				<li>Benoît Quenaudon <a href="https://twitter.com/oldergod">@oldergod</a>, <a href="https://benoitquenaudon.com">personal blog</a>, <a href="https://github.com/oldergod">GitHub</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="https://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-				</ul>
-
-				<h4>Links</h4>
-
-				<ul>
-				<li><a href="https://cycle.js.org">Cycle.js</a></li>
-				<li><a href="https://github.com/oldergod/android-architecture">Android Blueprint: ToDo App using MVI by Benoît</a></li>
-				<li><a href="https://www.youtube.com/watch?v=PXBXcHQeDLE">droidcon NYC 2017 - Model-View-Intent for Android</a></li>
-				<li><a href="http://hannesdorfmann.com/android/mosby3-mvi-8">In-App Navigation with Coordinators</a></li>
-				<li><a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">droidcon SF 2017 - The Reactive Workflow Pattern Update</a></li>
-				<li><a href="https://twitter.com/oldergod/status/999638960384233474">Benoît's Tweet</a>: "We see more and more "reactive" architectures on Android but I think you're doing it wrong if you have a <code>subscribe</code> in your presenter. Ideally, the presenter should be an ObservableTransformer."</li>
-				<li><a href="https://staltz.com/unidirectional-user-interface-architectures.html">Unidirectional User Interface Architectures</li>
-				</ul>]]></itunes:summary>
+      <description>We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</description>
+      <pubDate>Sun, 10 Jun 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part1.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part1.mp3" length="31423481" type="audio/mpeg"/>
+      <itunes:duration>00:37:06</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://cycle.js.org">Cycle.js</a></li>
+          <li><a href="https://github.com/oldergod/android-architecture">Android Blueprint: ToDo App using MVI by Benoît</a></li>
+          <li><a href="https://www.youtube.com/watch?v=PXBXcHQeDLE">droidcon NYC 2017 - Model-View-Intent for Android</a></li>
+          <li><a href="http://hannesdorfmann.com/android/mosby3-mvi-8">In-App Navigation with Coordinators</a></li>
+          <li><a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">droidcon SF 2017 - The Reactive Workflow Pattern Update</a></li>
+          <li><a href="https://twitter.com/oldergod/status/999638960384233474">Benoît's Tweet</a>: &quot;We see more and more &quot;reactive&quot; architectures on Android but I think you're doing it wrong if you have a <code>subscribe</code> in your presenter. Ideally, the presenter should be an ObservableTransformer.&quot;</li>
+          <li><a href="https://staltz.com/unidirectional-user-interface-architectures.html">Unidirectional User Interface Architectures</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Benoît Quenaudon: <a href="https://twitter.com/oldergod">Twitter</a>, <a href="https://github.com/oldergod">GitHub</a>, <a href="https://benoitquenaudon.com">website</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part2.mp3</guid>
       <title>Episode 19, Part 2: Model-View-Intent with Benoît Quenaudon from Square</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_19_Part2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95" rel="replies" type="text/html" />
-      <itunes:duration>48:37</itunes:duration>
-      <pubDate>Sun, 10 June 2018 09:35:00 EST</pubDate>
-      <enclosure length="41109583 " type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part2.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 19, Part 2: Model-View-Intent with Benoît Quenaudon from Square</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In the second part of episode #19 Artur and Hannes continue the discussion with Benoît Quenaudon from Square about Model-View-Intent.
-				We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</p>
-
-				<h3>Guest:</h3>
-
-				<ul>
-				<li>Benoît Quenaudon <a href="https://twitter.com/oldergod">@oldergod</a>, <a href="https://benoitquenaudon.com">personal blog</a>, <a href="https://github.com/oldergod">GitHub</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artur Dryomov <a href="https://twitter.com/arturdryomov">@arturdryomov</a>, <a href="https://arturdryomov.online/">personal blog</a>, <a href="https://github.com/ming13">GitHub</a></li>
-				</ul>
-
-				<h4>Links</h4>
-
-				<ul>
-				<li><a href="https://cycle.js.org">Cycle.js</a></li>
-				<li><a href="https://github.com/oldergod/android-architecture">Android Blueprint: ToDo App using MVI by Benoît</a></li>
-				<li><a href="https://www.youtube.com/watch?v=PXBXcHQeDLE">droidcon NYC 2017 - Model-View-Intent for Android</a></li>
-				<li><a href="http://hannesdorfmann.com/android/mosby3-mvi-8">In-App Navigation with Coordinators</a></li>
-				<li><a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">droidcon SF 2017 - The Reactive Workflow Pattern Update</a></li>
-				<li><a href="https://twitter.com/oldergod/status/999638960384233474">Benoît's Tweet</a>: "We see more and more "reactive" architectures on Android but I think you're doing it wrong if you have a <code>subscribe</code> in your presenter. Ideally, the presenter should be an ObservableTransformer."</li>
-				<li><a href="https://staltz.com/unidirectional-user-interface-architectures.html">Unidirectional User Interface Architectures</li>
-				</ul>]]></itunes:summary>
+      <description>We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</description>
+      <pubDate>Sun, 10 Jun 2018 09:35:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part2.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.19.part2.mp3" length="41109583" type="audio/mpeg"/>
+      <itunes:duration>00:48:37</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>We discussed the difference between MVP, MVVM and MVI, how to implement MVI, reusable components and how to test MVI based applications.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://cycle.js.org">Cycle.js</a></li>
+          <li><a href="https://github.com/oldergod/android-architecture">Android Blueprint: ToDo App using MVI by Benoît</a></li>
+          <li><a href="https://www.youtube.com/watch?v=PXBXcHQeDLE">droidcon NYC 2017 - Model-View-Intent for Android</a></li>
+          <li><a href="http://hannesdorfmann.com/android/mosby3-mvi-8">In-App Navigation with Coordinators</a></li>
+          <li><a href="https://www.youtube.com/watch?v=mvBVkU2mCF4">droidcon SF 2017 - The Reactive Workflow Pattern Update</a></li>
+          <li><a href="https://twitter.com/oldergod/status/999638960384233474">Benoît's Tweet</a>: &quot;We see more and more &quot;reactive&quot; architectures on Android but I think you're doing it wrong if you have a <code>subscribe</code> in your presenter. Ideally, the presenter should be an ObservableTransformer.&quot;</li>
+          <li><a href="https://staltz.com/unidirectional-user-interface-architectures.html">Unidirectional User Interface Architectures</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Benoît Quenaudon: <a href="https://twitter.com/oldergod">Twitter</a>, <a href="https://github.com/oldergod">GitHub</a>, <a href="https://benoitquenaudon.com">website</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artur Dryomov: <a href="https://twitter.com/arturdryomov">Twitter</a>, <a href="https://github.com/ming13">GitHub</a>, <a href="https://arturdryomov.online">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/95">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part1.mp3</guid>
       <title>Episode 20, Part 1: public final Agile</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_20_Part1.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97" rel="replies" type="text/html" />
+      <description>In this episode Artem and Hannes chatted with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</description>
+      <pubDate>Sun, 01 Jul 2018 09:35:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part1.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part1.mp3" length="61435124" type="audio/mpeg"/>
       <itunes:duration>01:12:50</itunes:duration>
-      <pubDate>Sun, 1 July 2018 09:35:00 EST</pubDate>
-      <enclosure length="61435124" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part1.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 20, Part 1: public final Agile</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In this episode Artem and Hannes chatted with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</p>
-
-				<h3>Guest:</h3>
-
-				<ul>
-				<li>Alexey Alexeev: <a href="https://www.linkedin.com/in/alexeev-alexey-6a83a88/">LinkedIn</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="https://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				</ul>
-
-				<h4>Links</h4>
-
-				<ul>
-				<li><a href="https://www.amazon.com/Turn-Ship-Around-Turning-Followers-ebook/dp/B00AFPVP0Y">Turn the Ship Around!</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Toyota_Production_System">Toyota Production System</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Jeff_Sutherland">Jeff Sutherland</a></li>
-				<li><a href="https://edu.leankanban.com/users/david-anderson">David Anderson</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Kaizen">Kaizen</a></li>
-				</ul>]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode Artem and Hannes chatted with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://www.amazon.com/Turn-Ship-Around-Turning-Followers-ebook/dp/B00AFPVP0Y">Turn the Ship Around!</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Toyota_Production_System">Toyota Production System</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Jeff_Sutherland">Jeff Sutherland</a></li>
+          <li><a href="https://edu.leankanban.com/users/david-anderson">David Anderson</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Kaizen">Kaizen</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Alexey Alexeev: <a href="https://www.linkedin.com/in/alexeev-alexey-6a83a88/">LinkedIn</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
     <item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part2.mp3</guid>
       <title>Episode 20, Part 2: public final Agile</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_20_Part2.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97" rel="replies" type="text/html" />
-      <itunes:duration>41:55</itunes:duration>
-      <pubDate>Sun, 1 July 2018 09:36:00 EST</pubDate>
-      <enclosure length="35472069" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part2.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 20, Part 2: public final Agile</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97">Discussion after the episode</a></li>
-				</ul>
-
-				<p>In this episode Artem and Hannes chatted with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</p>
-
-				<h3>Guest:</h3>
-
-				<ul>
-				<li>Alexey Alexeev: <a href="https://www.linkedin.com/in/alexeev-alexey-6a83a88/">LinkedIn</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				<li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="https://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				</ul>
-
-				<h4>Links</h4>
-
-				<ul>
-				<li><a href="https://www.amazon.com/Turn-Ship-Around-Turning-Followers-ebook/dp/B00AFPVP0Y">Turn the Ship Around!</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Toyota_Production_System">Toyota Production System</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Jeff_Sutherland">Jeff Sutherland</a></li>
-				<li><a href="https://edu.leankanban.com/users/david-anderson">David Anderson</a></li>
-				<li><a href="https://en.wikipedia.org/wiki/Kaizen">Kaizen</a></li>
-				</ul>]]></itunes:summary>
+      <description>Artem and Hannes continue the discussion with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</description>
+      <pubDate>Sun, 01 Jul 2018 09:36:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part2.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.20.part2.mp3" length="35472069" type="audio/mpeg"/>
+      <itunes:duration>00:41:55</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>Artem and Hannes continue the discussion with Alexey Alexeev about Agile, Scrum, Kanban and everything related to project management.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://www.amazon.com/Turn-Ship-Around-Turning-Followers-ebook/dp/B00AFPVP0Y">Turn the Ship Around!</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Toyota_Production_System">Toyota Production System</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Jeff_Sutherland">Jeff Sutherland</a></li>
+          <li><a href="https://edu.leankanban.com/users/david-anderson">David Anderson</a></li>
+          <li><a href="https://en.wikipedia.org/wiki/Kaizen">Kaizen</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Alexey Alexeev: <a href="https://www.linkedin.com/in/alexeev-alexey-6a83a88/">LinkedIn</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/97">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
-	<item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.21.mp3</guid>
+    <item>
       <title>Episode 21: Rx Must Die (droidcon Berlin 2018)</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_21.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/99" rel="replies" type="text/html" />
+      <description>We&#39;ve collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they&#39;ve recorded panel discussions for us and allowed us to publish them with our commentary.</description>
+      <pubDate>Wed, 01 Aug 2018 09:36:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.21.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.21.mp3" length="60920969" type="audio/mpeg"/>
       <itunes:duration>01:03:12</itunes:duration>
-      <pubDate>Wed, 1 August 2018 09:36:00 EST</pubDate>
-      <enclosure length="60920969" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.21.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 21: Rx Must Die (droidcon Berlin 2018)</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/99">Discussion after the episode</a></li>
-				</ul>
-
-				<p>This time we have a special episode!</p>
-
-				<p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary, many thanks droidcon Berlin 👍</p>
-
-				<p>This particular episode is a panel discussion with a very controversial title "Rx Must Die".
-				As you might know, all hosts of The Context podcast have very warm feelings about Rx and it was not an easy job for us to comment, Hannes and Artur were strong enough but Artem had to bail out (oof).</p>
-
-				<p>We hope you enjoy this episode and find things to think about, remember if you want to discuss them — we have discussions on GitHub (link above)!</p>
-
-				<p><strong>Pannelists:</strong></p>
-
-				<ul>
-				<li>Joannes Orgis, Microsoft Todo</li>
-				<li><a href="https://twitter.com/hamen">Ivan Morgillo</a>, Asana Rebel</li>
-				<li><a href="https://twitter.com/alosdev">Hasan Hosgel</a>, Lab1886 - Mercedes-Benz</li>
-				<li><a href="https://twitter.com/_ashdavies">Ash Davis</a>, ImmobilienScout24</li>
-				</ul>
-
-				<ul>
-				<li><a href="https://twitter.com/kevinmcdonagh">Kevin McDonagh</a>, Novoda</li>
-				</ul>
-
-				<p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
-	  ]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary.</p>
+          <p>This particular episode is a panel discussion with a very controversial title <em>Rx Must Die</em>. As you might know, all hosts of The Context podcast have very warm feelings about Rx and it was not an easy job for us to comment, Hannes and Artur were strong enough but Artem had to bail out (oof). We hope you enjoy this episode and find things to think about, remember if you want to discuss them — we have discussions on GitHub!</p>
+          <p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Ash Davis</li>
+          <li>Hasan Hosgel: <a href="https://twitter.com/alosdev">Twitter</a></li>
+          <li>Ivan Morgillo: <a href="https://twitter.com/hamen">Twitter</a>, <a href="https://github.com/hamen">GitHub</a></li>
+          <li>Joannes Orgis</li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Kevin McDonagh: <a href="https://twitter.com/kevinmcdonagh">Twitter</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/99">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
-	<item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.22.mp3</guid>
+    <item>
       <title>Episode 22: Women in Tech (droidcon Berlin 2018)</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_22.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/101" rel="replies" type="text/html" />
-      <itunes:duration>51:23</itunes:duration>
-      <pubDate>Fri, 17 August 2018 09:36:00 EST</pubDate>
-      <enclosure length="43425533" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.22.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 22: Women in Tech (droidcon Berlin 2018)</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/101">Discussion after the episode</a></li>
-				</ul>
-
-				<p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary, many thanks droidcon Berlin 👍</p>
-
-				<p><strong>Pannelists:</strong></p>
-
-				<ul>
-				<li><a href="https://twitter.com/brwngrldev">Annyce Davis</a>, Off Grid Electric</li>
-				<li><a href="https://twitter.com/lariki">Lara Martín</a>, Babbel </li>
-				<li><a href="https://twitter.com/kevinmcdonagh">Kevin McDonagh</a>, Novoda</li>
-				<li><a href="https://www.linkedin.com/in/vivien-dollinger">Vivien Dollinger</a>, ObjectBox</li>
-				<li><a href="https://twitter.com/anitas3791">Anita Singh</a>, Winnie</li>
-				</ul>
-
-				<p><strong>Panel Host:</strong></p>
-
-				<ul>
-				<li><a href="https://de.linkedin.com/in/daniela-gausmann">Daniela Gausmann</a>, ObjectBox</li>
-				</ul>
-
-				<p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
-	  ]]></itunes:summary>
+      <description>We&#39;ve collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they&#39;ve recorded panel discussions for us and allowed us to publish them with our commentary.</description>
+      <pubDate>Fri, 17 Aug 2018 09:36:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.22.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.22.mp3" length="43425533" type="audio/mpeg"/>
+      <itunes:duration>00:51:23</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary.</p>
+          <p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Anita Singh: <a href="https://twitter.com/anitas3791">Twitter</a></li>
+          <li>Annyce Davis: <a href="https://twitter.com/brwngrldev">Twitter</a></li>
+          <li>Kevin McDonagh: <a href="https://twitter.com/kevinmcdonagh">Twitter</a></li>
+          <li>Lara Martín: <a href="https://twitter.com/lariki">Twitter</a></li>
+          <li>Vivien Dollinger: <a href="https://www.linkedin.com/in/vivien-dollinger">LinkedIn</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Daniela Gausmann: <a href="https://linkedin.com/in/daniela-gausmann">LinkedIn</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/101">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
-	<item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.23.mp3</guid>
+    <item>
       <title>Episode 23: Rise of the Machines (droidcon Berlin 2018)</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_23.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/103" rel="replies" type="text/html" />
-      <itunes:duration>57:10</itunes:duration>
-      <pubDate>Wed, 19 September 2018 09:30:00 EST</pubDate>
-      <enclosure length="48276037" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.23.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 23: Rise of the Machines (droidcon Berlin 2018)</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/103">Discussion after the episode</a></li>
-				</ul>
-
-				<p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary, many thanks droidcon Berlin 👍</p>
-
-				<p><strong>Pannelists:</strong></p>
-
-				<ul>
-				<li><a href="https://twitter.com/silviacambie">Silvia Cambie</a>, IBM</li>
-				<li><a href="https://twitter.com/androidian60">Jürgen Fey</a>, Androidian </li>
-				<li><a href="https://twitter.com/meghafon">Meghan Kane</a>, Novoda</li>
-				<li><a href="https://twitter.com/hoitab">Hoi Lam</a>, Google</li>
-				<li>Dr. Roman Belter, APPSfactory</li>
-				</ul>
-
-				<p><strong>Panel Host:</strong></p>
-
-				<ul>
-				<li><a href="https://twitter.com/kevinmcdonagh">Kevin McDonagh</a>, Novoda</li>
-				</ul>
-
-				<p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
-	  ]]></itunes:summary>
+      <description>We&#39;ve collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they&#39;ve recorded panel discussions for us and allowed us to publish them with our commentary.</description>
+      <pubDate>Wed, 19 Sep 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.23.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.23.mp3" length="48276037" type="audio/mpeg"/>
+      <itunes:duration>00:57:10</itunes:duration>
+      <content:encoded>
+        <![CDATA[
+          <p>We've collaborated with droidcon Berlin 2018 (June 25) where Hannes was speaking about MVI, and they've recorded panel discussions for us and allowed us to publish them with our commentary.</p>
+          <p>Thanks droidcon Berlin and the local Berlin Android community for collaborating with us.</p>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Dr. Roman Belter</li>
+          <li>Hoi Lam: <a href="https://twitter.com/hoitab">Twitter</a></li>
+          <li>Jürgen Fey: <a href="https://twitter.com/androidian60">Twitter</a></li>
+          <li>Meghan Kane: <a href="https://twitter.com/meghafon">Twitter</a></li>
+          <li>Silvia Cambie: <a href="https://twitter.com/silviacambie">Twitter</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Kevin McDonagh: <a href="https://twitter.com/kevinmcdonagh">Twitter</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/103">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
-	<item>
-      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.24.mp3</guid>
+    <item>
       <title>Episode 24: Ok Multiplatform with Jesse Wilson and Egor Andreevich</title>
-      <link>https://github.com/artem-zinnatullin/TheContext-Podcast/blob/master/show_notes/Episode_24.md</link>
-      <atom:link href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/105" rel="replies" type="text/html" />
+      <description>In this episode Artem and Hannes chatted with Jesse and Egor from Square about multiplatform development with Kotlin.</description>
+      <pubDate>Thu, 27 Sep 2018 09:30:00 +0000</pubDate>
+      <guid>https://artemzin.com/static/thecontext/episodes/The.Context.episode.24.mp3</guid>
+      <enclosure url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.24.mp3" length="52048516" type="audio/mpeg"/>
       <itunes:duration>01:01:38</itunes:duration>
-      <pubDate>Thu, 27 September 2018 09:30:00 EST</pubDate>
-      <enclosure length="52048516" type="audio/mpeg" url="https://artemzin.com/static/thecontext/episodes/The.Context.episode.24.mp3" />
-      <itunes:summary><![CDATA[<h1>Episode 24: Ok Multiplatform with Jesse Wilson and Egor Andreevich</h1>
-
-				<h3><a href="https://github.com/artem-zinnatullin/TheContext-Podcast">How to listen &amp; subscribe</a></h3>
-
-				<ul>
-				<li><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/105">Discussion after the episode</a></li>
-				</ul>
-
-				<p><strong>Announcement:</strong> Please participate in <a href="https://docs.google.com/forms/d/1YMv1bn4jXBw9ozoW1q7mCoHTnmCDEh0OYhlRbLAgS1o/viewform">this survey</a> to give us feedback how we can make this podcast better.</p>
-
-				<p>In this episode Artem and Hannes chatted with Jesse and Egor from Square about multiplatform development with Kotlin. They shared their experience of migrating Okio to Kotlin and which strategies they have applied to make it multiplatform ready.</p>
-
-				<h4>Guest:</h4>
-
-				<ul>
-				<li>Jesse Wilson <a href="https://twitter.com/jessewilson">@jessewilson</a>, <a href="https://publicobject.com">Blog</a>, <a href="https://github.com/swankjesse">GitHub</a></li>
-				<li>Egor Andreevich <a href="https://twitter.com/EgorAnd">@EgorAnd</a>, <a href="https://blog.egorand.me">Blog</a>, <a href="https://github.com/Egorand">GitHub</a></li>
-				</ul>
-
-				<h4>Hosts:</h4>
-
-				<ul>
-				<li>Artem Zinnatullin <a href="https://twitter.com/artem_zin">@artem_zin</a>, <a href="http://artemzin.com">personal blog</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a></li>
-				<li>Hannes Dorfmann <a href="https://twitter.com/sockeqwe">@sockeqwe</a>, <a href="http://hannesdorfmann.com">personal blog</a>, <a href="https://github.com/sockeqwe">GitHub</a></li>
-				</ul>
-
-				<h4>Additional links:</h4>
-
-				<ul>
-				<li><a href="https://github.com/square/okio">Okio on Github</a></li>
-				<li><a href="https://medium.com/square-corner-blog/okio-2-6f6c35149525">Announcing Okio 2: Our fast + simple I/O library, Okio, has a new release that supports Kotlin.</a></li>
-				<li><a href="https://github.com/melix/japicmp-gradle-plugin">JApicmp: binary compatibility reporting</a></li>
-				<li><a href="https://docs.google.com/forms/d/1YMv1bn4jXBw9ozoW1q7mCoHTnmCDEh0OYhlRbLAgS1o/viewform">The Context Podcast Survey: Help us make the show better</a></li>
-				</ul>
-	  ]]></itunes:summary>
+      <content:encoded>
+        <![CDATA[
+          <p>In this episode Artem and Hannes chatted with Jesse and Egor from Square about multiplatform development with Kotlin.</p>
+          <p>Jesse and Egor shared their experience of migrating Okio to Kotlin and which strategies they have applied to make it multiplatform ready.</p>
+          <p><strong>Announcement:</strong> Please participate in <a href="https://docs.google.com/forms/d/1YMv1bn4jXBw9ozoW1q7mCoHTnmCDEh0OYhlRbLAgS1o/viewform">this survey</a> to give us feedback how we can make this podcast better.</p>
+          <p>Links:</p>
+          <ul>
+          <li><a href="https://github.com/square/okio">Okio on GitHub</a></li>
+          <li><a href="https://medium.com/square-corner-blog/okio-2-6f6c35149525">Announcing Okio 2: Our fast + simple I/O library, Okio, has a new release that supports Kotlin</a></li>
+          <li><a href="https://github.com/melix/japicmp-gradle-plugin">JApicmp: binary compatibility reporting</a></li>
+          <li><a href="https://docs.google.com/forms/d/1YMv1bn4jXBw9ozoW1q7mCoHTnmCDEh0OYhlRbLAgS1o/viewform">The Context Podcast Survey: Help us make the show better</a></li>
+          </ul>
+          <p><strong>Guests</strong></p>
+          <ul>
+          <li>Egor Andreevich: <a href="https://twitter.com/EgorAnd">Twitter</a>, <a href="https://github.com/Egorand">GitHub</a>, <a href="https://blog.egorand.me">blog</a></li>
+          <li>Jesse Wilson: <a href="https://twitter.com/jessewilson">Twitter</a>, <a href="https://github.com/swankjesse">GitHub</a>, <a href="https://publicobject.com">blog</a></li>
+          </ul>
+          <p><strong>Hosts</strong></p>
+          <ul>
+          <li>Artem Zinnatullin: <a href="https://twitter.com/artem_zin">Twitter</a>, <a href="https://github.com/artem-zinnatullin">GitHub</a>, <a href="https://artemzin.com">blog</a></li>
+          <li>Hannes Dorfmann: <a href="https://twitter.com/sockeqwe">Twitter</a>, <a href="https://github.com/sockeqwe">GitHub</a>, <a href="http://hannesdorfmann.com">blog</a></li>
+          </ul>
+          <p><strong>Discussion</strong></p>
+          <p><a href="https://github.com/artem-zinnatullin/TheContext-Podcast/issues/105">Give us your opinion on the episode</a>!</p>
+        ]]>
+      </content:encoded>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
The first step of migrating this repository to the organisation one is replacing the manual-made feed with the generated one. @sockeqwe is aware of most of them because he reviewed PRs related to the feed generator, but there is a brief overview anyway.

* `atom` namespace was nuked completely because podcast players and services do not use such tags at all.
* Time is always at the UTC timezone to avoid confusion.
* `itunes:author` includes all hosts and it should be visible now in all podcast players and services.
* `itunes:keywords` was removed since it was deprecated and not used a long time ago.
* `itunes:summary` and `itunes:subtitle` were removed in favor of `description` which is actually used instead of these two.
* `item.link` was removed since it is not used anywhere.
* `content:encoded` is used for HTML-like content since it is the only tag that actually can include this type of content and be rendered correctly in all players and services.
* There are probably some things I forgot about.

What I’m asking to do is two things.

* Try to add the podcast via URL in your podcast player of choice just to make sure everything is fine. I’ve tested the feed in Pocket Casts on Android, iTunes on macOS, Podcasts and Overcast on iOS, but I might have missed something.
* As far as I understand everything in feed definition can change except `guid`. It should have the same value as before since it is the field players and services consider as a unique ID. If there is a new one it will be shown as a new episode.